### PR TITLE
updateci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,54 +2,44 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
+    tags:
+      - "v*.*.*" # Trigger on version tags like v1.0.0
   pull_request:
-    branches: [ "main" ]
-  workflow_dispatch: # Allows manual triggering
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  lint_and_test:
+  lint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12"] # Specify the Python version
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+      - name: Run lint
+        run: make check
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
-
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-        installer-parallel: true
-
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v4
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
-    - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-      run: poetry install --no-interaction --no-root
-
-    - name: Install project
-      run: poetry install --no-interaction
-
-    - name: Lint with Pylint
-      run: make check
-
-    - name: Run tests with Pytest
-      run: make test
-    - run: echo "$(poetry env info --path)/bin" >> $GITHUB_PATH
-    - name: "Pyright"
-      uses: jakebailey/pyright-action@v2
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+      - name: Run tests
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,3 +44,34 @@ jobs:
         run: uv sync --all-extras --dev
       - name: Run tests
         run: make test
+
+  build-image:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,8 +23,8 @@ unit test:
     name: python:3.12
   stage: test
   before_script:
-    - pip install uv
-    - uv sync --all-extras --dev
+    - pip install uv -U
+    - uv sync --all-extras
   script:
     - make test
   coverage: '/(?i)total.*? (100(?:\.0+)?\%|[1-9]?\d(?:\.\d+)?\%)$/'
@@ -44,8 +44,8 @@ code lint:
     name: python:3.12
   stage: test
   before_script:
-    - pip install uv
-    - uv sync --all-extras --dev
+    - pip install uv -U
+    - uv sync --all-extras
   script:
     - make check
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,8 +23,8 @@ unit test:
     name: python:3.12
   stage: test
   before_script:
-    - pip install poetry -U
-    - poetry install
+    - pip install uv
+    - uv sync --all-extras --dev
   script:
     - make test
   coverage: '/(?i)total.*? (100(?:\.0+)?\%|[1-9]?\d(?:\.\d+)?\%)$/'
@@ -44,8 +44,8 @@ code lint:
     name: python:3.12
   stage: test
   before_script:
-    - pip install poetry -U
-    - poetry install
+    - pip install uv
+    - uv sync --all-extras --dev
   script:
     - make check
   tags:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ enginepy = "enginepy.cli:cli"
 
 [dependency-groups]
 dev = [
+"ruff",
     "aioresponses",
     "pyreadline",
     "pylint-pydantic",


### PR DESCRIPTION
- **> ci: Migrate CI pipelines from Poetry to uv**
  This commit updates GitHub Actions and GitLab CI to use `uv` for dependency management.
  - Updates `.github/workflows/ci.yml` and `.gitlab-ci.yml` to install `uv` and use `uv sync`.
  - Splits the GitHub CI `lint_and_test` job into separate `lint` and `test` jobs.
  - Removes publishing steps from the GitHub Actions workflow.
  

- **> ci: Add Docker image build to GitHub Actions and update GitLab CI**
  Integrate Docker image building and pushing to GHCR.
  Also, refine GitLab CI dependency management commands.
  
  *   Add a `build-image` job in GitHub Actions for Docker builds and pushes.
  *   Configure Docker builds to trigger on `main` branch pushes and version tags.
  *   Update GitLab CI jobs to use `pip install uv -U` and `uv sync --all-extras`.
  