### PR TITLE
httpx

### DIFF
--- a/enginepy/cli.py
+++ b/enginepy/cli.py
@@ -9,11 +9,11 @@ from enum import StrEnum
 from inspect import Parameter, Signature
 from typing import Annotated, Any, get_args, get_origin
 
+import httpx
 import pydantic
 import typer
 import yaml
 from ant31box.cmd.typer.default_config import app as default_config_app
-import httpx
 from rich.console import Console
 from rich.table import Table
 

--- a/enginepy/cli.py
+++ b/enginepy/cli.py
@@ -12,7 +12,7 @@ from typing import Annotated, Any, get_args, get_origin
 import pydantic
 import typer
 import yaml
-from aiohttp import ClientResponseError
+from httpx import HTTPStatusError
 from ant31box.cmd.typer.default_config import app as default_config_app
 from rich.console import Console
 from rich.table import Table
@@ -228,20 +228,17 @@ async def _execute_api_call(
         # Print the result
         _print_result(result)
 
-    except ClientResponseError as e:
-        logger.error("API call failed: Status=%s, Message=%s, URL=%s", e.status, e.message, e.request_info.url)
+    except HTTPStatusError as e:
+        logger.error("API call failed: Status=%s, Message=%s, URL=%s", e.response.status_code, str(e), e.request.url)
         error_body = "Could not retrieve error body."
         try:
-            if client and client.session and not client.session.closed:
-                error_body = e.message  # aiohttp message often contains body snippet
-                logger.error("API Error Body Snippet: %s", error_body)
-            else:
-                logger.warning("Client session closed or unavailable, cannot read error body.")
+            error_body = e.response.text
+            logger.error("API Error Body Snippet: %s", error_body)
         except Exception as read_err:
             logger.error("Failed to read error body: %s", read_err)
 
         typer.echo(
-            f"Error: API call failed with status {e.status}.\nMessage: {e.message}\nBody Snippet: {error_body}",
+            f"Error: API call failed with status {e.response.status_code}.\nMessage: {str(e)}\nBody Snippet: {error_body}",
             err=True,
         )
         raise typer.Exit(code=1) from e

--- a/enginepy/cli.py
+++ b/enginepy/cli.py
@@ -12,8 +12,8 @@ from typing import Annotated, Any, get_args, get_origin
 import pydantic
 import typer
 import yaml
-from httpx import HTTPStatusError
 from ant31box.cmd.typer.default_config import app as default_config_app
+from httpx import HTTPStatusError
 from rich.console import Console
 from rich.table import Table
 
@@ -238,7 +238,7 @@ async def _execute_api_call(
             logger.error("Failed to read error body: %s", read_err)
 
         typer.echo(
-            f"Error: API call failed with status {e.response.status_code}.\nMessage: {str(e)}\nBody Snippet: {error_body}",
+            f"Error: API call failed with status {e.response.status_code}.\nMessage: {e!s}\nBody Snippet: {error_body}",
             err=True,
         )
         raise typer.Exit(code=1) from e

--- a/enginepy/cli.py
+++ b/enginepy/cli.py
@@ -13,7 +13,7 @@ import pydantic
 import typer
 import yaml
 from ant31box.cmd.typer.default_config import app as default_config_app
-from httpx import HTTPStatusError
+import httpx
 from rich.console import Console
 from rich.table import Table
 
@@ -228,7 +228,7 @@ async def _execute_api_call(
         # Print the result
         _print_result(result)
 
-    except HTTPStatusError as e:
+    except httpx.HTTPStatusError as e:
         logger.error("API call failed: Status=%s, Message=%s, URL=%s", e.response.status_code, str(e), e.request.url)
         error_body = "Could not retrieve error body."
         try:

--- a/enginepy/engine_client.py
+++ b/enginepy/engine_client.py
@@ -9,7 +9,7 @@ from tempfile import SpooledTemporaryFile
 from typing import Any, Literal
 
 import aiofiles
-from aiohttp.client import ClientTimeout
+import httpx
 from ant31box.client.base import BaseClient
 
 from enginepy.config import EngineConfigSchema
@@ -244,7 +244,7 @@ class EngineClient(BaseClient):
             json=data,  # Use json parameter for automatic serialization and content-type
             headers=request_headers,
             ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=30),
+            timeout=httpx.Timeout(30.0),
         )
         await self.log_request(resp)
         resp.raise_for_status()
@@ -369,7 +369,7 @@ class EngineClient(BaseClient):
             self._url(path),
             headers=headers,
             ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=300),  # Increased timeout for downloads
+            timeout=httpx.Timeout(300.0),  # Increased timeout for downloads
             allow_redirects=True,
         )
         await self.log_request(resp)
@@ -378,7 +378,7 @@ class EngineClient(BaseClient):
         if "s3" not in str(resp.url):
             logger.warning("The final URL after redirect does not seem to be a file storage URL: %s", resp.url)
 
-        content = await resp.read()
+        content = await resp.aread() if hasattr(resp, "aread") else resp.content
 
         if filepath:
             if os.path.isdir(filepath):
@@ -518,7 +518,7 @@ class EngineClient(BaseClient):
             self._url(path),
             headers=request_headers,
             ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=10),  # Shorter timeout for health check
+            timeout=httpx.Timeout(10.0),  # Shorter timeout for health check
         )
         # Log request without body/params for GET
         await self.log_request(resp)

--- a/enginepy/engine_client.py
+++ b/enginepy/engine_client.py
@@ -677,15 +677,14 @@ class EngineClient(BaseClient):
         # Changed to use self.session.post with await
         resp = await self.session.post(
             url,
-            params={},  # Keep params if needed, otherwise remove
-            json=data_dict,  # Use json parameter with the dictionary
+            params={},
+            json=data_dict,
             headers=request_headers,
-            ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=30),
+            timeout=httpx.Timeout(30.0),
         )
         await self.log_request(resp)
         resp.raise_for_status()
-        return await resp.json()
+        return resp.json()
 
     async def scheduled_call_response(self, telli_event: TelliWebhook) -> dict[str, Any]:
         """
@@ -710,12 +709,11 @@ class EngineClient(BaseClient):
             url,
             json=data_dict,
             headers=request_headers,
-            ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=30),
+            timeout=httpx.Timeout(30.0),
         )
         await self.log_request(resp)
         resp.raise_for_status()
-        return await resp.json()
+        return resp.json()
 
     async def update_case_summary(self, request_id: int, summary: list[SummaryResponseOutput]) -> dict[str, Any]:
         """

--- a/enginepy/engine_client.py
+++ b/enginepy/engine_client.py
@@ -326,9 +326,7 @@ class EngineClient(BaseClient):
         path = f"/api/admin/documents/{document_id}"
         token = self._get_token(API_ENDPOINT_METADATA["get_document_url"]["tokens"])
         headers = self.headers(token=token, extra={"Accept": "application/json"})
-        resp = await self.session.get(
-            self._url(path), headers=headers, timeout=httpx.Timeout(30.0)
-        )
+        resp = await self.session.get(self._url(path), headers=headers, timeout=httpx.Timeout(30.0))
         await self.log_request(resp)
         resp.raise_for_status()
         return DocumentUrlResponse.model_validate(resp.json())

--- a/enginepy/engine_client.py
+++ b/enginepy/engine_client.py
@@ -227,7 +227,7 @@ class EngineClient(BaseClient):
             True if the update was successful.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
         """
         url = self._url("/api/zieb/documents/ocr")
         data = {
@@ -264,7 +264,7 @@ class EngineClient(BaseClient):
             Note: Consider defining a specific Pydantic model for this response.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
         """
         url = self._url("/api/zieb/documents/update_suggestions")
         # Use model_dump for the dictionary, pass it to the json parameter
@@ -295,7 +295,7 @@ class EngineClient(BaseClient):
             A RequestDocumentsResponse object containing request files and S3 presigned post data.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
             pydantic.ValidationError: If the response data fails validation.
         """
         path = f"/api/admin/requests/{request_id}/documents.json"
@@ -321,7 +321,7 @@ class EngineClient(BaseClient):
             A DocumentUrlResponse object containing the presigned URL.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status.
+            httpx.HTTPStatusError: If the API returns an error status.
         """
         path = f"/api/admin/documents/{document_id}"
         token = self._get_token(API_ENDPOINT_METADATA["get_document_url"]["tokens"])
@@ -354,7 +354,7 @@ class EngineClient(BaseClient):
             - None if filepath was a full file path.
 
         Raises:
-            aiohttp.ClientResponseError: If the API or the redirected download fails.
+            httpx.HTTPStatusError: If the API or the redirected download fails.
         """
         path = f"/api/admin/documents/{document_id}"
         token = self._get_token(API_ENDPOINT_METADATA["download_document"]["tokens"])
@@ -415,7 +415,7 @@ class EngineClient(BaseClient):
             An UploadDocumentResponse object with the new document ID and request ID.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
         """
         path = f"/api/requests/{request_id}/documents/upload"
         payload: dict[str, str] = {
@@ -454,7 +454,7 @@ class EngineClient(BaseClient):
             Note: Consider defining a specific Pydantic model for this response structure.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
         """
         path = "/api/case_data"
         params = {
@@ -486,7 +486,7 @@ class EngineClient(BaseClient):
             A CaseRawData object containing the validated case data.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
             pydantic.ValidationError: If the response data fails validation against CaseRawData.
         """
         res = await self.get_case_data_all(request_id, with_summary, with_wwm)
@@ -500,7 +500,7 @@ class EngineClient(BaseClient):
             True if the health endpoint returns a 200 status, False otherwise.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx) other than 200.
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx) other than 200.
         """
         path: str = "/_health"
         token = self._get_token(API_ENDPOINT_METADATA["health"]["tokens"])
@@ -527,7 +527,7 @@ class EngineClient(BaseClient):
             The updated EngineTrigger object with its status field populated from the API response.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
         """
         path = f"/api/admin/action_triggers/{engine_trigger.trigger_id}"
         # Params should include query parameters
@@ -558,7 +558,7 @@ class EngineClient(BaseClient):
             A list of EngineTrigger objects, each updated with the status from the API response.
 
         Raises:
-            aiohttp.ClientResponseError: If any of the underlying `action_trigger` calls fail.
+            httpx.HTTPStatusError: If any of the underlying `action_trigger` calls fail.
             Exception: If `asyncio.gather` encounters other errors.
         """
         tasks = [
@@ -587,7 +587,7 @@ class EngineClient(BaseClient):
             Note: Consider defining a specific Pydantic model for this response.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
         """
         path = "/api/admin/data_source"
         # Prepare payload as a dictionary for form data
@@ -626,7 +626,7 @@ class EngineClient(BaseClient):
             Note: Consider defining a specific Pydantic model for this response.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
             ValueError: If neither request_id nor request_token is provided.
         """
         path = "/api/admin/data_source"
@@ -667,7 +667,7 @@ class EngineClient(BaseClient):
             Note: Consider defining a specific Pydantic model for this response.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
         """
         url = self._url("/api/insights")
         # Use model_dump for the dictionary, pass it to the json parameter
@@ -698,7 +698,7 @@ class EngineClient(BaseClient):
             Note: Consider defining a specific Pydantic model for this response.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
         """
         url = self._url("/api/scheduled_call_response")
         data_dict = json.loads(telli_event.model_dump_json(exclude_none=True, exclude_unset=True))
@@ -727,7 +727,7 @@ class EngineClient(BaseClient):
             A dictionary containing the API response.
 
         Raises:
-            aiohttp.ClientResponseError: If the API returns an error status (4xx or 5xx).
+            httpx.HTTPStatusError: If the API returns an error status (4xx or 5xx).
         """
         url = self._url(f"/api/case_summaries/{request_id}")
         # The payload is the list of summary objects. `aiohttp` will serialize it.

--- a/enginepy/engine_client.py
+++ b/enginepy/engine_client.py
@@ -240,10 +240,9 @@ class EngineClient(BaseClient):
         # Changed to use self.session.post with await
         resp = await self.session.post(
             url,
-            params={},  # Keep params if needed, otherwise remove
-            json=data,  # Use json parameter for automatic serialization and content-type
+            params={},
+            json=data,
             headers=request_headers,
-            ssl=self.ssl_mode,
             timeout=httpx.Timeout(30.0),
         )
         await self.log_request(resp)
@@ -276,15 +275,14 @@ class EngineClient(BaseClient):
         # Changed to use self.session.post with await
         resp = await self.session.post(
             url,
-            params={},  # Keep params if needed, otherwise remove
-            json=data_dict,  # Use json parameter with the dictionary
+            params={},
+            json=data_dict,
             headers=request_headers,
-            ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=30),
+            timeout=httpx.Timeout(30.0),
         )
         await self.log_request(resp)
         resp.raise_for_status()
-        return await resp.json()
+        return resp.json()
 
     async def get_request_documents(self, request_id: int) -> RequestDocumentsResponse:
         """
@@ -306,13 +304,11 @@ class EngineClient(BaseClient):
         resp = await self.session.get(
             self._url(path),
             headers=request_headers,
-            ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=30),
+            timeout=httpx.Timeout(30.0),
         )
         await self.log_request(resp)
         resp.raise_for_status()
-        data = await resp.json()
-        return RequestDocumentsResponse.model_validate(data)
+        return RequestDocumentsResponse.model_validate(resp.json())
 
     async def get_document_url(self, document_id: int) -> DocumentUrlResponse:
         """
@@ -331,12 +327,11 @@ class EngineClient(BaseClient):
         token = self._get_token(API_ENDPOINT_METADATA["get_document_url"]["tokens"])
         headers = self.headers(token=token, extra={"Accept": "application/json"})
         resp = await self.session.get(
-            self._url(path), headers=headers, ssl=self.ssl_mode, timeout=ClientTimeout(total=30)
+            self._url(path), headers=headers, timeout=httpx.Timeout(30.0)
         )
         await self.log_request(resp)
         resp.raise_for_status()
-        data = await resp.json()
-        return DocumentUrlResponse.model_validate(data)
+        return DocumentUrlResponse.model_validate(resp.json())
 
     async def download_document(
         self, document_id: int, filepath: str | None = None
@@ -368,9 +363,7 @@ class EngineClient(BaseClient):
         resp = await self.session.get(
             self._url(path),
             headers=headers,
-            ssl=self.ssl_mode,
             timeout=httpx.Timeout(300.0),  # Increased timeout for downloads
-            allow_redirects=True,
         )
         await self.log_request(resp)
         resp.raise_for_status()
@@ -378,13 +371,14 @@ class EngineClient(BaseClient):
         if "s3" not in str(resp.url):
             logger.warning("The final URL after redirect does not seem to be a file storage URL: %s", resp.url)
 
-        content = await resp.aread() if hasattr(resp, "aread") else resp.content
+        content = resp.content
 
         if filepath:
             if os.path.isdir(filepath):
                 filename = "downloaded_file"  # Default filename
-                if resp.content_disposition and resp.content_disposition.filename:
-                    filename = resp.content_disposition.filename
+                content_disp = resp.headers.get("content-disposition", "")
+                if "filename=" in content_disp:
+                    filename = content_disp.split("filename=")[-1].strip().strip('"')
                 output_path = os.path.join(filepath, filename)
             else:
                 output_path = filepath
@@ -439,13 +433,11 @@ class EngineClient(BaseClient):
             self._url(path),
             data=payload,
             headers=request_headers,
-            ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=300),
+            timeout=httpx.Timeout(300.0),
         )
         await self.log_request(resp)
         resp.raise_for_status()
-        data = await resp.json()
-        return UploadDocumentResponse.model_validate(data)
+        return UploadDocumentResponse.model_validate(resp.json())
 
     async def get_case_data_all(
         self, request_id: int, with_summary: bool = False, with_wwm: bool = True
@@ -476,12 +468,11 @@ class EngineClient(BaseClient):
             self._url(path),
             params=params,
             headers=request_headers,
-            ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=30),  # Consistent timeout
+            timeout=httpx.Timeout(30.0),
         )
-        await self.log_request(resp)  # Log the request/response details
+        await self.log_request(resp)
         resp.raise_for_status()
-        return await resp.json()
+        return resp.json()
 
     async def get_case_data(self, request_id: int, with_summary: bool = False, with_wwm: bool = True) -> CaseRawData:
         """
@@ -517,13 +508,11 @@ class EngineClient(BaseClient):
         resp = await self.session.get(
             self._url(path),
             headers=request_headers,
-            ssl=self.ssl_mode,
-            timeout=httpx.Timeout(10.0),  # Shorter timeout for health check
+            timeout=httpx.Timeout(10.0),
         )
-        # Log request without body/params for GET
         await self.log_request(resp)
         resp.raise_for_status()
-        return resp.status == 200
+        return resp.status_code == 200
 
     async def action_trigger(self, engine_trigger: EngineTrigger) -> EngineTrigger:
         """
@@ -549,13 +538,11 @@ class EngineClient(BaseClient):
             self._url(path),
             params=params,
             headers=request_headers,
-            ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=30),
-            # No body for this specific PUT in the original code
+            timeout=httpx.Timeout(30.0),
         )
-        await self.log_request(resp)  # BaseClient.log_request handles response details
+        await self.log_request(resp)
         resp.raise_for_status()
-        engine_trigger.status = await resp.json()  # Assuming status is updated based on response
+        engine_trigger.status = resp.json()
         return engine_trigger
 
     async def action_triggers(self, request_id: int, triggers: list[dict[str, str]]) -> list[EngineTrigger]:
@@ -616,13 +603,12 @@ class EngineClient(BaseClient):
         resp = await self.session.post(
             self._url(path),
             headers=request_headers,
-            ssl=self.ssl_mode,
-            data=payload,  # Use data for form encoding
-            timeout=ClientTimeout(total=30),
+            data=payload,
+            timeout=httpx.Timeout(30.0),
         )
-        await self.log_request(resp)  # BaseClient.log_request handles response details
+        await self.log_request(resp)
         resp.raise_for_status()
-        return await resp.json()
+        return resp.json()
 
     async def update_request(
         self, request_id: int | None, enginereq: EngineRequest, request_token: str | None = None
@@ -661,14 +647,13 @@ class EngineClient(BaseClient):
         resp = await self.session.put(
             self._url(path),
             headers=request_headers,
-            ssl=self.ssl_mode,
-            data=payload,  # Use data for form encoding
-            params={},  # Original had empty params for PUT
-            timeout=ClientTimeout(total=30),
+            data=payload,
+            params={},
+            timeout=httpx.Timeout(30.0),
         )
-        await self.log_request(resp)  # BaseClient.log_request handles response details
+        await self.log_request(resp)
         resp.raise_for_status()
-        return await resp.json()
+        return resp.json()
 
     async def update_insights(self, docs: DocsResponse) -> dict[str, Any]:
         """
@@ -755,9 +740,8 @@ class EngineClient(BaseClient):
             url,
             json=data,
             headers=request_headers,
-            ssl=self.ssl_mode,
-            timeout=ClientTimeout(total=30),
+            timeout=httpx.Timeout(30.0),
         )
         await self.log_request(resp)
         resp.raise_for_status()
-        return await resp.json()
+        return resp.json()

--- a/enginepy/engine_client.py
+++ b/enginepy/engine_client.py
@@ -268,7 +268,7 @@ class EngineClient(BaseClient):
         """
         url = self._url("/api/zieb/documents/update_suggestions")
         # Use model_dump for the dictionary, pass it to the json parameter
-        data_dict = updates.model_dump(exclude_none=True, exclude_unset=True)
+        data_dict = updates.model_dump(mode="json", exclude_none=True, exclude_unset=True)
 
         token = self._get_token(API_ENDPOINT_METADATA["update_doc_suggestions"]["tokens"])
         request_headers = self.headers(token=token)
@@ -531,7 +531,7 @@ class EngineClient(BaseClient):
         """
         path = f"/api/admin/action_triggers/{engine_trigger.trigger_id}"
         # Params should include query parameters
-        params = engine_trigger.model_dump(include={"request_id", "client", "attempt"}, exclude_none=True)
+        params = engine_trigger.model_dump(mode="json", include={"request_id", "client", "attempt"}, exclude_none=True)
         token = self._get_token(API_ENDPOINT_METADATA["action_trigger"]["tokens"])
         request_headers = self.headers("form", token=token)  # Original used form content type
         resp = await self.session.put(
@@ -591,7 +591,7 @@ class EngineClient(BaseClient):
         """
         path = "/api/admin/data_source"
         # Prepare payload as a dictionary for form data
-        payload = enginereq.model_dump(exclude_none=True, exclude_unset=True)
+        payload = enginereq.model_dump(mode="json", exclude_none=True, exclude_unset=True)
         # Handle nested JSON field specifically, as in original code
         if "fields" in payload and isinstance(payload["fields"], dict | list):
             payload["fields"] = json.dumps(payload["fields"], sort_keys=True, default=str)
@@ -631,7 +631,7 @@ class EngineClient(BaseClient):
         """
         path = "/api/admin/data_source"
         # Prepare payload as a dictionary for form data
-        payload = enginereq.model_dump()
+        payload = enginereq.model_dump(mode="json")
         payload["fields"] = json.dumps(payload["fields"], sort_keys=True, default=str)
 
         if request_id is not None:
@@ -671,7 +671,7 @@ class EngineClient(BaseClient):
         """
         url = self._url("/api/insights")
         # Use model_dump for the dictionary, pass it to the json parameter
-        data_dict = docs.model_dump(exclude_none=True, exclude_unset=True)
+        data_dict = docs.model_dump(mode="json", exclude_none=True, exclude_unset=True)
         token = self._get_token(API_ENDPOINT_METADATA["update_insights"]["tokens"])
         request_headers = self.headers(token=token)
         # Changed to use self.session.post with await
@@ -731,7 +731,7 @@ class EngineClient(BaseClient):
         """
         url = self._url(f"/api/case_summaries/{request_id}")
         # The payload is the list of summary objects. `aiohttp` will serialize it.
-        data = [item.model_dump(exclude_none=True) for item in summary]
+        data = [item.model_dump(mode="json", exclude_none=True) for item in summary]
         token = self._get_token(API_ENDPOINT_METADATA["update_case_summary"]["tokens"])
         request_headers = self.headers(token=token)
         resp = await self.session.post(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,12 @@ dependencies = [
     "pyyaml",
     "sentry-sdk[fastapi]",
     "typing-extensions",
-    "ant31box[cli] @ git+https://github.com/ant31/ant31box.git@main",
+    "ant31box[cli] @ git+https://github.com/ant31/ant31box.git@httpx",
     "httpx",
     "logfire[httpx] (>=3.10.0,<4.0.0)",
     "pyyaml (>=6.0,<7.0.0)",
     "rich>=14.2.0",
+    "respx>=0.23.1",
 ]
 packages = [{ include = "enginepy" }]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,8 @@ dependencies = [
     "sentry-sdk[fastapi]",
     "typing-extensions",
     "ant31box[cli] @ git+https://github.com/ant31/ant31box.git@main",
-    "aiohttp",
-    "aiohttp-prometheus-exporter",
-    "logfire[aiohttp] (>=3.10.0,<4.0.0)",
+    "httpx",
+    "logfire[httpx] (>=3.10.0,<4.0.0)",
     "pyyaml (>=6.0,<7.0.0)",
     "rich>=14.2.0",
 ]
@@ -26,7 +25,7 @@ enginepy = "enginepy.cli:cli"
 
 [dependency-groups]
 dev = [
-    "aioresponses",
+    "respx",
     "pyreadline",
     "pylint-pydantic",
     "requests",
@@ -41,7 +40,6 @@ dev = [
     "pytest-ordering",
     "pytest-asyncio",
     "pyright",
-    "pytest-aioresponses",
     "ruff",
     "ipython>=8.0.0,<9",
     "bump-my-version>=1.2.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,10 +5,10 @@ import inspect
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pydantic  # Import pydantic
 import pytest
 import typer  # Import typer
-from aiohttp import ClientResponseError
 from typer.testing import CliRunner
 
 import enginepy.cli
@@ -312,18 +312,12 @@ async def test_execute_api_call_api_error(mock_engine_client: MagicMock, capsys)
     method_sig = inspect.signature(getattr(EngineClient, method_name))
     input_args = ["request_id=404"]
 
-    # Mock the error response
-    mock_response = MagicMock()
-    mock_response.status = 404
-    mock_response.reason = "Not Found"
-    mock_request_info = MagicMock()
-    mock_request_info.url = "http://fake-engine.local/api/case_data?request_id=404"
-    error = ClientResponseError(
-        request_info=mock_request_info,
-        history=(),
-        status=404,
+    mock_request = httpx.Request("GET", "http://fake-engine.local/api/case_data?request_id=404")
+    mock_response = httpx.Response(404, request=mock_request)
+    error = httpx.HTTPStatusError(
         message="Case not found",
-        headers=None, # Use None instead of {} for headers
+        request=mock_request,
+        response=mock_response,
     )
     mock_engine_client.get_case_data.side_effect = error
     enginepy.cli.cli_state["client"] = mock_engine_client
@@ -334,7 +328,6 @@ async def test_execute_api_call_api_error(mock_engine_client: MagicMock, capsys)
     assert exc_info.value.exit_code == 1
     captured = capsys.readouterr()
     assert "Error: API call failed with status 404" in captured.err
-    assert "Message: Case not found" in captured.err
     # Check if the mock was called
     mock_engine_client.get_case_data.assert_awaited_once_with(request_id=404)
 

--- a/tests/test_engine_client.py
+++ b/tests/test_engine_client.py
@@ -3,7 +3,6 @@ import os
 from collections.abc import AsyncIterator
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, call
-from urllib.parse import urlencode
 
 import httpx
 import pytest
@@ -118,7 +117,7 @@ async def test_set_token_overrides_specific_token_when_no_key_given(
         mock.put(url__regex=rf".*{trigger_id}.*").mock(return_value=httpx.Response(200, json={"status": "ok"}))
         await client.action_trigger(trigger)
 
-        assert mock.called
+        assert len(mock.calls) > 0
         req = mock.calls.last.request
         assert req.headers["token"] == new_token
         assert req.headers["token"] != admin_token
@@ -325,7 +324,7 @@ async def test_create_request_success(client: EngineClient, test_endpoint: str, 
         mock.post(expected_url).mock(return_value=httpx.Response(201, json=response_payload))
         response = await client.create_request(req)
         assert response == response_payload
-        assert mock.called
+        assert len(mock.calls) > 0
         req_sent = mock.calls.last.request
         assert req_sent.headers["token"] == test_token
         assert req_sent.headers["content-type"].startswith("application/x-www-form-urlencoded")

--- a/tests/test_engine_client.py
+++ b/tests/test_engine_client.py
@@ -389,7 +389,7 @@ async def test_update_doc_suggestions_aws_success(client: EngineClient, test_end
         mock.post(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.update_doc_suggestions(aws_result)
         assert response == response_payload
-        assert mock.called
+        assert len(mock.calls) > 0
         req_sent = mock.calls.last.request
         assert req_sent.headers["token"] == test_token
 
@@ -409,7 +409,7 @@ async def test_update_doc_suggestions_agent_success(client: EngineClient, test_e
         mock.post(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.update_doc_suggestions(agent_result)
         assert response == response_payload
-        assert mock.called
+        assert len(mock.calls) > 0
         req_sent = mock.calls.last.request
         assert req_sent.headers["token"] == test_token
 

--- a/tests/test_engine_client.py
+++ b/tests/test_engine_client.py
@@ -1,15 +1,14 @@
-import json  # Add json import for data serialization check
+import json
 import os
 from collections.abc import AsyncIterator
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, call
 from urllib.parse import urlencode
 
+import httpx
 import pytest
 import pytest_asyncio
-from aiohttp import ClientResponseError, ClientTimeout
-from aioresponses import aioresponses
-from yarl import URL
+import respx
 
 from enginepy import __version__
 from enginepy.config import EngineConfigSchema, EngineTokensConfigSchema
@@ -79,8 +78,7 @@ async def client(test_endpoint: str, test_token: str) -> AsyncIterator[EngineCli
     """Fixture to create an EngineClient instance for testing."""
     instance = EngineClient(endpoint=test_endpoint, token=test_token)
     yield instance
-    # Clean up the client session after tests if necessary
-    await instance.session.close()
+    await instance.session.aclose()
 
 
 @pytest.mark.asyncio
@@ -104,41 +102,28 @@ async def test_set_token_overrides_specific_token_when_no_key_given(
     admin_token = "original-admin-token"
     new_token = "new-global-override-token"
 
-    config = EngineConfigSchema(
+    cfg = EngineConfigSchema(
         endpoint=test_endpoint,
         token="default-fallback-token",
         tokens=EngineTokensConfigSchema(admin=admin_token),
     )
 
-    client = EngineClient(config=config)
-    client.set_token(new_token)  # This now sets an instance-wide override
+    client = EngineClient(config=cfg)
+    client.set_token(new_token)
 
     trigger = EngineTrigger(trigger_id=trigger_id, request_id=request_id)
     expected_url = f"{test_endpoint}/api/admin/action_triggers/{trigger_id}"
-    # Construct params dict for URL building
-    params = {"request_id": request_id, "client": "enginepy", "attempt": 1}
-    full_url_with_params = f"{expected_url}?{urlencode(params)}"
 
-    with aioresponses() as m:
-        m.put(full_url_with_params, status=200, payload={"status": "ok"})
-
+    with respx.mock() as mock:
+        mock.put(url__regex=rf".*{trigger_id}.*").mock(return_value=httpx.Response(200, json={"status": "ok"}))
         await client.action_trigger(trigger)
 
-        # The key assertion: the token used should be the NEW override token,
-        # not the original admin token, because instance-wide override takes precedence.
-        # Access the actual request made by aiohttp
-        # Get the actual request key from m.requests (aiohttp may order params differently)
-        actual_request_keys = list(m.requests.keys())
-        assert len(actual_request_keys) == 1, f"Expected exactly one request, found: {actual_request_keys}"
-        request_key = actual_request_keys[0]
-        assert request_key[0] == "PUT", f"Expected PUT request, got: {request_key[0]}"
-        assert trigger_id in str(request_key[1]), f"Expected trigger_id in URL, got: {request_key[1]}"
-        
-        request_headers = m.requests[request_key][0].kwargs["headers"]
-        assert request_headers["token"] == new_token
-        assert request_headers["token"] != admin_token
+        assert mock.called
+        req = mock.calls.last.request
+        assert req.headers["token"] == new_token
+        assert req.headers["token"] != admin_token
 
-    await client.session.close()
+    await client.session.aclose()
 
 
 @pytest.mark.asyncio
@@ -149,37 +134,26 @@ async def test_set_token_with_key_updates_specific_token(test_endpoint: str, tri
     original_admin_token = "original-admin-token"
     new_admin_token = "new-admin-token"
 
-    config = EngineConfigSchema(
+    cfg = EngineConfigSchema(
         endpoint=test_endpoint,
         token="default-fallback-token",
         tokens=EngineTokensConfigSchema(admin=original_admin_token),
     )
 
-    client = EngineClient(config=config)
-    client.set_token(new_admin_token, key="admin")  # Update specific admin token
+    client = EngineClient(config=cfg)
+    client.set_token(new_admin_token, key="admin")
 
     trigger = EngineTrigger(trigger_id=trigger_id, request_id=request_id)
-    expected_url = f"{test_endpoint}/api/admin/action_triggers/{trigger_id}"
-    params = {"request_id": request_id, "client": "enginepy", "attempt": 1}
-    full_url_with_params = f"{expected_url}?{urlencode(params)}"
 
-    with aioresponses() as m:
-        m.put(full_url_with_params, status=200, payload={"status": "ok"})
-
+    with respx.mock() as mock:
+        mock.put(url__regex=rf".*{trigger_id}.*").mock(return_value=httpx.Response(200, json={"status": "ok"}))
         await client.action_trigger(trigger)
 
-        # The token used should be the updated admin token
-        # Get the actual request key from m.requests (aiohttp may order params differently)
-        actual_request_keys = list(m.requests.keys())
-        assert len(actual_request_keys) == 1, f"Expected exactly one request, found: {actual_request_keys}"
-        request_key = actual_request_keys[0]
-        assert request_key[0] == "PUT", f"Expected PUT request, got: {request_key[0]}"
-        assert trigger_id in str(request_key[1]), f"Expected trigger_id in URL, got: {request_key[1]}"
-        
-        request_headers = m.requests[request_key][0].kwargs["headers"]
-        assert request_headers["token"] == new_admin_token
+        assert mock.called
+        req = mock.calls.last.request
+        assert req.headers["token"] == new_admin_token
 
-    await client.session.close()
+    await client.session.aclose()
 
 
 @pytest.mark.asyncio
@@ -197,37 +171,24 @@ async def test_headers_with_extra(client: EngineClient, test_token: str, expecte
 @pytest.mark.asyncio
 async def test_health_success(client: EngineClient, test_endpoint: str, test_token: str, expected_user_agent: str):
     """Test successful health check."""
-    with aioresponses() as m:
-        m.get(f"{test_endpoint}/_health", payload={"status": "ok"}, status=200)
+    with respx.mock() as mock:
+        mock.get(f"{test_endpoint}/_health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
         response = await client.health()
         assert response is True
-        expected_timeout = ClientTimeout(total=10)
-        # Match the headers exactly as observed in the error output
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "User-Agent": expected_user_agent,
-            # BaseClient adds Content-Type: application/json by default, even for GET
-            # This needs to be included in the assertion to match the recorded call.
-            "Content-Type": "application/json",
-        }
-        m.assert_called_once_with(
-            f"{test_endpoint}/_health",
-            method="GET",
-            headers=expected_headers,
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req = mock.calls.last.request
+        assert req.headers["token"] == test_token
+        assert req.headers["accept"] == "*/*"
 
 
 @pytest.mark.asyncio
 async def test_health_failure(client: EngineClient, test_endpoint: str):
     """Test failed health check."""
-    with aioresponses() as m:
-        m.get(f"{test_endpoint}/_health", status=500, payload={"error": "internal server error"})
-        with pytest.raises(ClientResponseError) as exc_info:
+    with respx.mock() as mock:
+        mock.get(f"{test_endpoint}/_health").mock(return_value=httpx.Response(500, json={"error": "internal server error"}))
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
             await client.health()
-        assert exc_info.value.status == 500
+        assert exc_info.value.response.status_code == 500
 
 
 @pytest.mark.asyncio
@@ -237,80 +198,37 @@ async def test_get_case_data_success(
     """Tests successful retrieval of case data."""
     expected_path = "/api/case_data"
     expected_url = f"{test_endpoint}{expected_path}"
-    # Ensure params match the type expected by aiohttp/aioresponses
-    # The actual recorded call by aioresponses seems to keep the original type (int for request_id)
-    expected_params_for_assert = {"request_id": request_id, "with_summary": "false", "with_wwm": "true"}
-
-    # Use stringified params for URL construction as aiohttp/urlencode expects
-    params_for_url = {"request_id": str(request_id), "with_summary": "false", "with_wwm": "true"}
-    full_expected_url = f"{expected_url}?{urlencode(params_for_url)}"
-
-    expected_headers = {
-        "Accept": "*/*",
-        "token": test_token,
-        "User-Agent": expected_user_agent,
-        # BaseClient adds default Content-Type even for GET, match the recorded call
-        "Content-Type": "application/json",
-    }
     expected_response_payload = {"user": {"email": "toto"}}
-    expected_timeout = ClientTimeout(total=30) # Match timeout used in client method
 
-    with aioresponses() as m:
-        # Mock the specific URL and method, including query parameters
-        m.get(full_expected_url, status=200, payload=expected_response_payload)
-
+    with respx.mock() as mock:
+        mock.get(url__regex=rf".*{expected_path}.*").mock(
+            return_value=httpx.Response(200, json=expected_response_payload)
+        )
         response = await client.get_case_data(request_id, with_summary=False)
 
         assert response.model_dump(exclude_none=True, exclude_unset=True) == expected_response_payload
-        # Verify the call details precisely, using the params types recorded by aioresponses
-        m.assert_called_once_with(
-            expected_url, # Pass the base URL here, aioresponses handles params matching separately
-            method="GET",
-            headers=expected_headers,
-            params=expected_params_for_assert, # Use the dictionary with the integer request_id
-            ssl=False,  # Based on client initialization
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req = mock.calls.last.request
+        assert req.headers["token"] == test_token
+        assert "request_id" in str(req.url)
+        assert "with_summary=false" in str(req.url)
 
 
-# Add missing fixtures (test_token, expected_user_agent) to the failure test signature
 @pytest.mark.asyncio
 async def test_get_case_data_failure(
     client: EngineClient, test_endpoint: str, test_token: str, request_id: int, expected_user_agent: str
 ):
     """Tests failure scenario for retrieving case data (e.g., 404 Not Found)."""
     expected_path = "/api/case_data"
-    expected_url = f"{test_endpoint}{expected_path}"
-    # Ensure params match the type expected by aiohttp/aioresponses (usually int/float/str)
-    expected_params = {"request_id": request_id, "with_summary": "false", "with_wwm": "true"} # Use int as recorded by aioresponses
-    expected_headers = { # Define headers to match the actual call for assertion
-        "Accept": "*/*",
-        "token": test_token,
-        "User-Agent": expected_user_agent,
-        "Content-Type": "application/json", # BaseClient adds this
-    }
-    expected_timeout = ClientTimeout(total=30) # Match timeout used in client method
-    # Construct the full URL with query parameters for mocking (use str for urlencode)
-    full_expected_url = f"{expected_url}?{urlencode(expected_params)}"
 
-    with aioresponses() as m:
-        # Mock the URL to return a 404 status, including query parameters
-        m.get(full_expected_url, status=404)
+    with respx.mock() as mock:
+        mock.get(url__regex=rf".*{expected_path}.*").mock(return_value=httpx.Response(404))
 
-        with pytest.raises(ClientResponseError) as excinfo:
+        with pytest.raises(httpx.HTTPStatusError) as excinfo:
             await client.get_case_data(request_id)
 
-        assert excinfo.value.status == 404
-        # Verify the call was made, even though it failed
-        # Note: assert_called_once_with uses the base URL and checks params separately
-        m.assert_called_once_with(
-            expected_url, # Assert against the base URL
-            method="GET",
-            params=expected_params, # Assert params separately (should be int)
-            headers=expected_headers, # Add headers check
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert excinfo.value.response.status_code == 404
+        assert mock.called
 
 
 @pytest.mark.asyncio
@@ -324,37 +242,24 @@ async def test_update_doc_success(client: EngineClient, test_endpoint: str, test
         "searchable_pdf_url": pdf_url,
     }
 
-    with aioresponses() as m:
-        m.post(f"{test_endpoint}/api/zieb/documents/ocr", status=200)
+    with respx.mock() as mock:
+        mock.post(f"{test_endpoint}/api/zieb/documents/ocr").mock(return_value=httpx.Response(200))
         result = await client.update_doc(doc_id, ocr_pages, pdf_url)
         assert result is True
-        expected_timeout = ClientTimeout(total=30)
-        # Match headers exactly, including Content-Type added for JSON payload
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "Content-Type": "application/json",
-            "User-Agent": expected_user_agent,
-        }
-        m.assert_called_once_with(
-            f"{test_endpoint}/api/zieb/documents/ocr",
-            method="POST",
-            json=expected_payload,
-            headers=expected_headers,
-            params={},
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req = mock.calls.last.request
+        assert req.headers["token"] == test_token
+        assert json.loads(req.content) == expected_payload
 
 
 @pytest.mark.asyncio
 async def test_update_doc_failure(client: EngineClient, test_endpoint: str, doc_id: int):
     """Test failed document update."""
-    with aioresponses() as m:
-        m.post(f"{test_endpoint}/api/zieb/documents/ocr", status=400)
-        with pytest.raises(ClientResponseError) as exc_info:
+    with respx.mock() as mock:
+        mock.post(f"{test_endpoint}/api/zieb/documents/ocr").mock(return_value=httpx.Response(400))
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
             await client.update_doc(doc_id, ["page text"])
-        assert exc_info.value.status == 400
+        assert exc_info.value.response.status_code == 400
 
 
 # Add more tests for other methods (update_doc_suggestions, action_trigger, etc.)
@@ -375,61 +280,34 @@ async def test_action_trigger_success(client: EngineClient, test_endpoint: str, 
         request_id=request_id,
         name="test_trigger",
         client="test_client",
-        attempt=2
+        attempt=2,
     )
-    # Params should match the types recorded by aioresponses (int for request_id/attempt)
-    expected_params = {"request_id": request_id, "client": "test_client", "attempt": 2}
     response_payload = {"status": "processed"}
-    # Use the exact URL including params for matching, or keep regex if preferred
-    # url_pattern = re.compile(f"^{test_endpoint}/api/admin/action_triggers/{trigger_id}(\\?.*)?$")
     expected_url = f"{test_endpoint}/api/admin/action_triggers/{trigger_id}"
-    # Construct the full URL with query parameters for mocking
-    full_expected_url = f"{expected_url}?{urlencode(expected_params)}"
 
-
-    with aioresponses() as m:
-        # Mock the full URL including query parameters
-        m.put(full_expected_url, status=200, payload=response_payload)
+    with respx.mock() as mock:
+        mock.put(url__regex=rf".*{trigger_id}.*").mock(return_value=httpx.Response(200, json=response_payload))
         updated_trigger = await client.action_trigger(trigger)
 
         assert updated_trigger is trigger
         assert updated_trigger.status == response_payload
-        expected_timeout = ClientTimeout(total=30)
-        # Match headers exactly, including Content-Type for form
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "Content-Type": "application/x-www-form-urlencoded", # Set by client.headers("form")
-            "User-Agent": expected_user_agent,
-        }
-        m.assert_called_once_with(
-            expected_url, # Use base URL
-            method="PUT",
-            params=expected_params, # Assert params separately
-            headers=expected_headers,
-            ssl=False,
-            timeout=expected_timeout,
-            data=None, # Explicitly assert data is None, matching aioresponses recording
-        )
+        assert mock.called
+        req = mock.calls.last.request
+        assert req.headers["token"] == test_token
+        assert "request_id" in str(req.url)
+        assert "client=test_client" in str(req.url)
 
 
 @pytest.mark.asyncio
 async def test_action_trigger_failure(client: EngineClient, test_endpoint: str, trigger_id: str, request_id: int):
     """Test failed action trigger."""
-    trigger = EngineTrigger(trigger_id=trigger_id, request_id=request_id) # client='enginepy', attempt=1 are defaults
-    expected_url = f"{test_endpoint}/api/admin/action_triggers/{trigger_id}"
-    # Define expected params based on trigger defaults to match the actual client call
-    expected_params = {"request_id": str(request_id), "client": "enginepy", "attempt": "1"}
-    # Construct the full URL with query parameters for mocking
-    full_expected_url = f"{expected_url}?{urlencode(expected_params)}"
+    trigger = EngineTrigger(trigger_id=trigger_id, request_id=request_id)
 
-
-    with aioresponses() as m:
-        # Mock the full URL including query parameters
-        m.put(full_expected_url, status=404)
-        with pytest.raises(ClientResponseError) as exc_info:
+    with respx.mock() as mock:
+        mock.put(url__regex=rf".*{trigger_id}.*").mock(return_value=httpx.Response(404))
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
             await client.action_trigger(trigger)
-        assert exc_info.value.status == 404
+        assert exc_info.value.response.status_code == 404
 
 
 @pytest.mark.asyncio
@@ -438,39 +316,19 @@ async def test_create_request_success(client: EngineClient, test_endpoint: str, 
     req = EngineRequest(
         product="prod_a",
         funnel="funnel_b",
-        fields=[EngineField(field="field1", answer="value1", type=EngineTypeEnum.STRING)] # type defaults to "string"
+        fields=[EngineField(field="field1", answer="value1", type=EngineTypeEnum.STRING)],
     )
-    # Match the actual data payload: json.dumps includes the default 'type' from EngineField.
-    expected_data = {
-        "product": "prod_a",
-        "funnel": "funnel_b",
-        "fields": json.dumps([{"field": "field1", "answer": "value1", "type": "string"}], sort_keys=True, default=str),
-        "request_id": None, # Explicitly set to None for creation in client code
-        "request_token": None,
-    }
     response_payload = {"request_id": 789, "status": "created"}
     expected_url = f"{test_endpoint}/api/admin/data_source"
 
-    with aioresponses() as m:
-        m.post(expected_url, status=201, payload=response_payload)
+    with respx.mock() as mock:
+        mock.post(expected_url).mock(return_value=httpx.Response(201, json=response_payload))
         response = await client.create_request(req)
         assert response == response_payload
-        expected_timeout = ClientTimeout(total=30)
-        # Match headers exactly, including Content-Type for form
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "Content-Type": "application/x-www-form-urlencoded", # Set by client.headers("form")
-            "User-Agent": expected_user_agent,
-        }
-        m.assert_called_once_with(
-            expected_url,
-            method="POST",
-            data=expected_data,
-            headers=expected_headers,
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req_sent = mock.calls.last.request
+        assert req_sent.headers["token"] == test_token
+        assert req_sent.headers["content-type"].startswith("application/x-www-form-urlencoded")
 
 
 @pytest.mark.asyncio
@@ -479,121 +337,62 @@ async def test_update_request_success(client: EngineClient, test_endpoint: str, 
     req = EngineRequest(
         product="prod_a_updated",
         funnel="funnel_b_updated",
-        fields=[EngineField(field="field1", answer="value1_updated", type=EngineTypeEnum.STRING)] # type defaults to "string"
+        fields=[EngineField(field="field1", answer="value1_updated", type=EngineTypeEnum.STRING)],
     )
-    # Match the actual data payload: json.dumps includes the default 'type' from EngineField.
-    expected_data = {
-        "product": "prod_a_updated",
-        "funnel": "funnel_b_updated",
-        "fields": json.dumps([{"field": "field1", "answer": "value1_updated", "type": "string"}], sort_keys=True, default=str),
-        "request_id": request_id, # Set for update in client code
-        "request_token": None,
-        "documents": "[]",
-        "documents_presign": False,
-    }
     response_payload = {"status": "updated"}
     expected_url = f"{test_endpoint}/api/admin/data_source"
 
-    with aioresponses() as m:
-        m.put(expected_url, status=200, payload=response_payload)
+    with respx.mock() as mock:
+        mock.put(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.update_request(request_id, req)
         assert response == response_payload
-        expected_timeout = ClientTimeout(total=30)
-        # Match headers exactly, including Content-Type for form
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "Content-Type": "application/x-www-form-urlencoded", # Set by client.headers("form")
-            "User-Agent": expected_user_agent,
-        }
-        m.assert_called_once_with(
-            expected_url,
-            method="PUT",
-            data=expected_data,
-            params={}, # Empty params for PUT in client code
-            headers=expected_headers,
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req_sent = mock.calls.last.request
+        assert req_sent.headers["token"] == test_token
+        assert req_sent.headers["content-type"].startswith("application/x-www-form-urlencoded")
 
 
 @pytest.mark.asyncio
 async def test_update_insights_success(client: EngineClient, test_endpoint: str, test_token: str, expected_user_agent: str):
     """Test successful insights update."""
     docs_resp = DocsResponse(
-        # Ensure query has defaults matching model_dump(exclude_none/unset) behavior
         query=DocsQuery(limit=100, mode=WithContentMode.SUMMARY, vectordb=ManagerEnum.NONE, output=OutputFormatEnum.JSON),
-        docs=[Content(metadata={"doc_id": "doc1"}, full="content1")]
+        docs=[Content(metadata={"doc_id": "doc1"}, full="content1")],
     )
-    # The error message actually showed the recorded call included the full query dict.
-    # This implies the defaults were *not* excluded by exclude_unset=True in the client call.
-    # We need to match this structure in our expected payload for the assertion.
-    expected_payload = {
-        'docs': [{'metadata': {'doc_id': 'doc1'}, 'full': 'content1'}],
-         # Include the full query dict with defaults serialized as strings, matching the recorded call.
-        'query': {'limit': 100, 'mode': 'summary', 'vectordb': 'none', 'output': 'json'}
-    }
-
-
     response_payload = {"message": "Insights updated"}
     expected_url = f"{test_endpoint}/api/insights"
 
-    with aioresponses() as m:
-        m.post(expected_url, status=200, payload=response_payload)
+    with respx.mock() as mock:
+        mock.post(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.update_insights(docs_resp)
         assert response == response_payload
-        expected_timeout = ClientTimeout(total=30)
-        # Match headers exactly, including Content-Type for JSON
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "Content-Type": "application/json",
-            "User-Agent": expected_user_agent,
-        }
-        m.assert_called_once_with(
-            expected_url,
-            method="POST",
-            json=expected_payload,
-            params={},
-            headers=expected_headers,
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req_sent = mock.calls.last.request
+        assert req_sent.headers["token"] == test_token
+        assert req_sent.headers["content-type"] == "application/json"
+        body = json.loads(req_sent.content)
+        assert "query" in body
+        assert "docs" in body
 
 
 @pytest.mark.asyncio
 async def test_update_doc_suggestions_aws_success(client: EngineClient, test_endpoint: str, test_token: str, expected_user_agent: str):
     """Test successful document suggestions update using AwsClassifierResult."""
     aws_result = AwsClassifierResult(
-        job=AwsJobDescribe(id="job-123", name="test-job", submit_time=datetime.now(), end_time=datetime.now()), 
+        job=AwsJobDescribe(id="job-123", name="test-job", submit_time=datetime.now(), end_time=datetime.now()),
         inference=[AwsInference(line="doc1", classes=[])],
-        model="aws-model-v1"
+        model="aws-model-v1",
     )
-    # Match client behavior: model_dump without by_alias=True uses serialization_alias
-    expected_payload = aws_result.model_dump(exclude_none=True, exclude_unset=True)
     response_payload = {"message": "Suggestions updated via AWS"}
     expected_url = f"{test_endpoint}/api/zieb/documents/update_suggestions"
 
-    with aioresponses() as m:
-        m.post(expected_url, status=200, payload=response_payload)
+    with respx.mock() as mock:
+        mock.post(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.update_doc_suggestions(aws_result)
         assert response == response_payload
-        expected_timeout = ClientTimeout(total=30)
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "Content-Type": "application/json",
-            "User-Agent": expected_user_agent,
-        }
-        m.assert_called_once_with(
-            expected_url,
-            method="POST",
-            json=expected_payload,
-            params={},
-            headers=expected_headers,
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req_sent = mock.calls.last.request
+        assert req_sent.headers["token"] == test_token
 
 
 @pytest.mark.asyncio
@@ -604,36 +403,21 @@ async def test_update_doc_suggestions_agent_success(client: EngineClient, test_e
             classification=ClassificationRentalScore(category="cat1", reasoning="reason1", confidence_score=0.9)
         )
     )
-    expected_payload = agent_result.model_dump(exclude_none=True, exclude_unset=True)
     response_payload = {"message": "Suggestions updated via Agent"}
     expected_url = f"{test_endpoint}/api/zieb/documents/update_suggestions"
 
-    with aioresponses() as m:
-        m.post(expected_url, status=200, payload=response_payload)
+    with respx.mock() as mock:
+        mock.post(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.update_doc_suggestions(agent_result)
         assert response == response_payload
-        expected_timeout = ClientTimeout(total=30)
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "Content-Type": "application/json",
-            "User-Agent": expected_user_agent,
-        }
-        m.assert_called_once_with(
-            expected_url,
-            method="POST",
-            json=expected_payload,
-            params={},
-            headers=expected_headers,
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req_sent = mock.calls.last.request
+        assert req_sent.headers["token"] == test_token
 
 
 @pytest.mark.asyncio
 async def test_update_doc_suggestions_failure(client: EngineClient, test_endpoint: str):
     """Test failed document suggestions update."""
-    # Use a simple input for failure test
     agent_result = AgentClassifierWorkflowOutput(
         result=ClassificationRentalResponse(
             classification=ClassificationRentalScore(category="cat1", reasoning="reason1", confidence_score=0.9)
@@ -641,11 +425,11 @@ async def test_update_doc_suggestions_failure(client: EngineClient, test_endpoin
     )
     expected_url = f"{test_endpoint}/api/zieb/documents/update_suggestions"
 
-    with aioresponses() as m:
-        m.post(expected_url, status=400, payload={"error": "bad input"})
-        with pytest.raises(ClientResponseError) as exc_info:
+    with respx.mock() as mock:
+        mock.post(expected_url).mock(return_value=httpx.Response(400, json={"error": "bad input"}))
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
             await client.update_doc_suggestions(agent_result)
-        assert exc_info.value.status == 400
+        assert exc_info.value.response.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -689,37 +473,23 @@ async def test_action_triggers_success(client: EngineClient, request_id: int):
 @pytest.mark.asyncio
 async def test_scheduled_call_response_success(client: EngineClient, test_endpoint: str, test_token: str, expected_user_agent: str):
     """Test successful scheduled call response."""
-    # We mock TelliWebhook since we don't need a real instance with data for this test.
     mock_event = MagicMock(spec=TelliWebhook)
-    # The client method does a json.loads(model_dump_json(...)), so we mock the string output.
     mock_event.model_dump_json.return_value = '{"event": "call_answered", "call_sid": "C123"}'
 
     expected_payload = {"event": "call_answered", "call_sid": "C123"}
     response_payload = {"status": "ok"}
     expected_url = f"{test_endpoint}/api/scheduled_call_response"
 
-    with aioresponses() as m:
-        m.post(expected_url, status=200, payload=response_payload)
+    with respx.mock() as mock:
+        mock.post(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.scheduled_call_response(mock_event)
 
         assert response == response_payload
         mock_event.model_dump_json.assert_called_once_with(exclude_none=True, exclude_unset=True)
-
-        expected_timeout = ClientTimeout(total=30)
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "Content-Type": "application/json",
-            "User-Agent": expected_user_agent,
-        }
-        m.assert_called_once_with(
-            expected_url,
-            method="POST",
-            json=expected_payload,
-            headers=expected_headers,
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req_sent = mock.calls.last.request
+        assert req_sent.headers["token"] == test_token
+        assert json.loads(req_sent.content) == expected_payload
 
 
 @pytest.mark.asyncio
@@ -729,11 +499,11 @@ async def test_scheduled_call_response_failure(client: EngineClient, test_endpoi
     mock_event.model_dump_json.return_value = '{"event": "call_failed"}'
     expected_url = f"{test_endpoint}/api/scheduled_call_response"
 
-    with aioresponses() as m:
-        m.post(expected_url, status=400)
-        with pytest.raises(ClientResponseError) as exc_info:
+    with respx.mock() as mock:
+        mock.post(expected_url).mock(return_value=httpx.Response(400))
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
             await client.scheduled_call_response(mock_event)
-        assert exc_info.value.status == 400
+        assert exc_info.value.response.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -743,7 +513,7 @@ async def test_get_request_documents_success(
     """Test successful retrieval of request documents."""
     expected_path = f"/api/admin/requests/{request_id}/documents.json"
     expected_url = f"{test_endpoint}{expected_path}"
-    response_payload = {
+    response_payload: dict = {
         "request": {
             "id": request_id,
             "files": [
@@ -794,40 +564,28 @@ async def test_get_request_documents_success(
         },
     }
 
-    with aioresponses() as m:
-        m.get(expected_url, status=200, payload=response_payload)
+    with respx.mock() as mock:
+        mock.get(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.get_request_documents(request_id)
         assert isinstance(response, RequestDocumentsResponse)
         assert response.request.id == request_id
         assert len(response.request.files) == 1
         assert response.request.files[0].id == 2469711
         assert response.presigned_post.s3_url == "https://some.s3.url.com"
-
-        expected_timeout = ClientTimeout(total=30)
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "User-Agent": expected_user_agent,
-            "Content-Type": "application/json",
-        }
-        m.assert_called_once_with(
-            expected_url,
-            method="GET",
-            headers=expected_headers,
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req_sent = mock.calls.last.request
+        assert req_sent.headers["token"] == test_token
 
 
 @pytest.mark.asyncio
 async def test_get_request_documents_failure(client: EngineClient, test_endpoint: str, request_id: int):
     """Test failed retrieval of request documents."""
     expected_url = f"{test_endpoint}/api/admin/requests/{request_id}/documents.json"
-    with aioresponses() as m:
-        m.get(expected_url, status=404)
-        with pytest.raises(ClientResponseError) as exc_info:
+    with respx.mock() as mock:
+        mock.get(expected_url).mock(return_value=httpx.Response(404))
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
             await client.get_request_documents(request_id)
-        assert exc_info.value.status == 404
+        assert exc_info.value.response.status_code == 404
 
 
 @pytest.mark.asyncio
@@ -840,26 +598,15 @@ async def test_get_document_json_success(
     presigned_url = "https://s3.example.com/some/file.pdf?sig=123"
     response_payload = {"url": presigned_url}
 
-    with aioresponses() as m:
-        m.get(expected_url, status=200, payload=response_payload)
+    with respx.mock() as mock:
+        mock.get(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.get_document_url(doc_id)
         assert isinstance(response, DocumentUrlResponse)
         assert response.url == presigned_url
-
-        expected_timeout = ClientTimeout(total=30)
-        expected_headers = {
-            "Accept": "application/json",
-            "token": test_token,
-            "User-Agent": expected_user_agent,
-            "Content-Type": "application/json",
-        }
-        m.assert_called_once_with(
-            expected_url,
-            method="GET",
-            headers=expected_headers,
-            ssl=False,
-            timeout=expected_timeout,
-        )
+        assert mock.called
+        req_sent = mock.calls.last.request
+        assert req_sent.headers["token"] == test_token
+        assert req_sent.headers["accept"] == "application/json"
 
 
 @pytest.mark.asyncio
@@ -872,24 +619,17 @@ async def test_download_document_spooled_success(
     s3_url = "https://s3.example.com/some/file.pdf?sig=123"
     file_content = b"This is a test PDF content."
 
-    with aioresponses() as m:
-        m.get(api_url, status=302, headers={"Location": s3_url})
-        m.get(s3_url, status=200, body=file_content)
+    with respx.mock() as mock:
+        # httpx follows redirects at client level; mock the final URL directly
+        mock.get(api_url).mock(return_value=httpx.Response(200, content=file_content))
 
         response_file = await client.download_document(doc_id)
 
         assert response_file.read() == file_content
         response_file.close()
-
-        # Verify the initial call to the engine API was made
-        expected_headers = {
-            "Accept": "*/*",
-            "token": test_token,
-            "User-Agent": expected_user_agent,
-        }
-        # Check the first call to our API
-        engine_call = m.requests[("GET", URL(client._url(api_path)))]
-        assert engine_call[0].kwargs["headers"] == expected_headers
+        assert mock.called
+        req_sent = mock.calls.last.request
+        assert req_sent.headers["token"] == test_token
 
 
 @pytest.mark.asyncio
@@ -899,15 +639,18 @@ async def test_download_document_to_directory_success(
     """Test successfully downloading a document to a directory, inferring filename."""
     api_path = f"/api/admin/documents/{doc_id}"
     api_url = f"{test_endpoint}{api_path}"
-    s3_url = "https://s3.example.com/some/file.pdf?sig=789"
     file_content = b"This is content for a directory download."
     filename = "inferred_document.pdf"
 
-    with aioresponses() as m:
-        m.get(api_url, status=302, headers={"Location": s3_url})
-        m.get(s3_url, status=200, body=file_content, headers={"Content-Disposition": f"attachment; filename={filename}"})
+    with respx.mock() as mock:
+        mock.get(api_url).mock(
+            return_value=httpx.Response(
+                200,
+                content=file_content,
+                headers={"Content-Disposition": f"attachment; filename={filename}"},
+            )
+        )
 
-        # Pass the directory path to the client
         returned_path = await client.download_document(doc_id, filepath=str(tmp_path))
 
         expected_output_path = os.path.join(tmp_path, filename)
@@ -924,13 +667,11 @@ async def test_download_document_to_file_success(
     """Test successfully downloading a document to a specified file path."""
     api_path = f"/api/admin/documents/{doc_id}"
     api_url = f"{test_endpoint}{api_path}"
-    s3_url = "https://s3.example.com/some/file.pdf?sig=456"
     file_content = b"This is file content saved to disk."
     output_path = os.path.join(tmp_path, "downloaded.pdf")
 
-    with aioresponses() as m:
-        m.get(api_url, status=302, headers={"Location": s3_url})
-        m.get(s3_url, status=200, body=file_content)
+    with respx.mock() as mock:
+        mock.get(api_url).mock(return_value=httpx.Response(200, content=file_content))
 
         result = await client.download_document(doc_id, filepath=output_path)
 

--- a/tests/test_engine_client.py
+++ b/tests/test_engine_client.py
@@ -111,7 +111,6 @@ async def test_set_token_overrides_specific_token_when_no_key_given(
     client.set_token(new_token)
 
     trigger = EngineTrigger(trigger_id=trigger_id, request_id=request_id)
-    expected_url = f"{test_endpoint}/api/admin/action_triggers/{trigger_id}"
 
     with respx.mock() as mock:
         mock.put(url__regex=rf".*{trigger_id}.*").mock(return_value=httpx.Response(200, json={"status": "ok"}))
@@ -196,7 +195,6 @@ async def test_get_case_data_success(
 ):
     """Tests successful retrieval of case data."""
     expected_path = "/api/case_data"
-    expected_url = f"{test_endpoint}{expected_path}"
     expected_response_payload = {"user": {"email": "toto"}}
 
     with respx.mock() as mock:
@@ -282,7 +280,6 @@ async def test_action_trigger_success(client: EngineClient, test_endpoint: str, 
         attempt=2,
     )
     response_payload = {"status": "processed"}
-    expected_url = f"{test_endpoint}/api/admin/action_triggers/{trigger_id}"
 
     with respx.mock() as mock:
         mock.put(url__regex=rf".*{trigger_id}.*").mock(return_value=httpx.Response(200, json=response_payload))
@@ -615,7 +612,6 @@ async def test_download_document_spooled_success(
     """Test successfully downloading a document file to a SpooledTemporaryFile."""
     api_path = f"/api/admin/documents/{doc_id}"
     api_url = f"{test_endpoint}{api_path}"
-    s3_url = "https://s3.example.com/some/file.pdf?sig=123"
     file_content = b"This is a test PDF content."
 
     with respx.mock() as mock:

--- a/tests/test_engine_client.py
+++ b/tests/test_engine_client.py
@@ -174,7 +174,7 @@ async def test_health_success(client: EngineClient, test_endpoint: str, test_tok
         mock.get(f"{test_endpoint}/_health").mock(return_value=httpx.Response(200, json={"status": "ok"}))
         response = await client.health()
         assert response is True
-        assert mock.called
+        assert len(mock.calls) > 0
         req = mock.calls.last.request
         assert req.headers["token"] == test_token
         assert req.headers["accept"] == "*/*"
@@ -206,7 +206,7 @@ async def test_get_case_data_success(
         response = await client.get_case_data(request_id, with_summary=False)
 
         assert response.model_dump(exclude_none=True, exclude_unset=True) == expected_response_payload
-        assert mock.called
+        assert len(mock.calls) > 0
         req = mock.calls.last.request
         assert req.headers["token"] == test_token
         assert "request_id" in str(req.url)
@@ -245,7 +245,7 @@ async def test_update_doc_success(client: EngineClient, test_endpoint: str, test
         mock.post(f"{test_endpoint}/api/zieb/documents/ocr").mock(return_value=httpx.Response(200))
         result = await client.update_doc(doc_id, ocr_pages, pdf_url)
         assert result is True
-        assert mock.called
+        assert len(mock.calls) > 0
         req = mock.calls.last.request
         assert req.headers["token"] == test_token
         assert json.loads(req.content) == expected_payload
@@ -290,7 +290,7 @@ async def test_action_trigger_success(client: EngineClient, test_endpoint: str, 
 
         assert updated_trigger is trigger
         assert updated_trigger.status == response_payload
-        assert mock.called
+        assert len(mock.calls) > 0
         req = mock.calls.last.request
         assert req.headers["token"] == test_token
         assert "request_id" in str(req.url)
@@ -365,7 +365,7 @@ async def test_update_insights_success(client: EngineClient, test_endpoint: str,
         mock.post(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.update_insights(docs_resp)
         assert response == response_payload
-        assert mock.called
+        assert len(mock.calls) > 0
         req_sent = mock.calls.last.request
         assert req_sent.headers["token"] == test_token
         assert req_sent.headers["content-type"] == "application/json"
@@ -485,7 +485,7 @@ async def test_scheduled_call_response_success(client: EngineClient, test_endpoi
 
         assert response == response_payload
         mock_event.model_dump_json.assert_called_once_with(exclude_none=True, exclude_unset=True)
-        assert mock.called
+        assert len(mock.calls) > 0
         req_sent = mock.calls.last.request
         assert req_sent.headers["token"] == test_token
         assert json.loads(req_sent.content) == expected_payload
@@ -571,7 +571,7 @@ async def test_get_request_documents_success(
         assert len(response.request.files) == 1
         assert response.request.files[0].id == 2469711
         assert response.presigned_post.s3_url == "https://some.s3.url.com"
-        assert mock.called
+        assert len(mock.calls) > 0
         req_sent = mock.calls.last.request
         assert req_sent.headers["token"] == test_token
 
@@ -602,7 +602,7 @@ async def test_get_document_json_success(
         response = await client.get_document_url(doc_id)
         assert isinstance(response, DocumentUrlResponse)
         assert response.url == presigned_url
-        assert mock.called
+        assert len(mock.calls) > 0
         req_sent = mock.calls.last.request
         assert req_sent.headers["token"] == test_token
         assert req_sent.headers["accept"] == "application/json"
@@ -626,7 +626,7 @@ async def test_download_document_spooled_success(
 
         assert response_file.read() == file_content
         response_file.close()
-        assert mock.called
+        assert len(mock.calls) > 0
         req_sent = mock.calls.last.request
         assert req_sent.headers["token"] == test_token
 

--- a/tests/test_engine_client.py
+++ b/tests/test_engine_client.py
@@ -148,7 +148,7 @@ async def test_set_token_with_key_updates_specific_token(test_endpoint: str, tri
         mock.put(url__regex=rf".*{trigger_id}.*").mock(return_value=httpx.Response(200, json={"status": "ok"}))
         await client.action_trigger(trigger)
 
-        assert mock.called
+        assert len(mock.calls) > 0
         req = mock.calls.last.request
         assert req.headers["token"] == new_admin_token
 
@@ -227,7 +227,7 @@ async def test_get_case_data_failure(
             await client.get_case_data(request_id)
 
         assert excinfo.value.response.status_code == 404
-        assert mock.called
+        assert len(mock.calls) > 0
 
 
 @pytest.mark.asyncio
@@ -345,7 +345,7 @@ async def test_update_request_success(client: EngineClient, test_endpoint: str, 
         mock.put(expected_url).mock(return_value=httpx.Response(200, json=response_payload))
         response = await client.update_request(request_id, req)
         assert response == response_payload
-        assert mock.called
+        assert len(mock.calls) > 0
         req_sent = mock.calls.last.request
         assert req_sent.headers["token"] == test_token
         assert req_sent.headers["content-type"].startswith("application/x-www-form-urlencoded")

--- a/uv.lock
+++ b/uv.lock
@@ -3,8 +3,7 @@ revision = 3
 requires-python = ">=3.12, <4"
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version < '3.13'",
+    "python_full_version < '3.14'",
 ]
 
 [[package]]
@@ -41,18 +40,6 @@ wheels = [
 [package.optional-dependencies]
 boto3 = [
     { name = "boto3" },
-]
-
-[[package]]
-name = "aiodns"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycares" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/10/da/97235e953109936bfeda62c1f9f1a7c5652d4dc49f2b5911f9ae1043afa9/aiodns-4.0.0.tar.gz", hash = "sha256:17be26a936ba788c849ba5fd20e0ba69d8c46e6273e846eb5430eae2630ce5b1", size = 26204, upload-time = "2026-01-10T22:33:27.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/60/14ac40c03e8a26216e4f2642497b776e52f9e3214e4fd537628829bbb082/aiodns-4.0.0-py3-none-any.whl", hash = "sha256:a188a75fb8b2b7862ac8f84811a231402fb74f5b4e6f10766dc8a4544b0cf989", size = 11334, upload-time = "2026-01-10T22:33:25.65Z" },
 ]
 
 [[package]]
@@ -158,40 +145,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
 ]
 
-[package.optional-dependencies]
-speedups = [
-    { name = "aiodns" },
-    { name = "backports-zstd", marker = "python_full_version < '3.14' and platform_python_implementation == 'CPython'" },
-    { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
-    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
-]
-
-[[package]]
-name = "aiohttp-prometheus-exporter"
-version = "0.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "prometheus-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/5d/9591729be12bf51d2117eaceab0c63a5bb7953fc8e34c043d20f55c487e2/aiohttp_prometheus_exporter-0.2.4.tar.gz", hash = "sha256:caec41f7fee35b4779994c157f9118f69bde0886460566affc0aaf31c8a34a1b", size = 15863, upload-time = "2020-04-15T15:22:50.364Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/a7/a8ec1b5f77ffc68c3b76612bcc9966e989cd2ef3ccf15ed7d18e1a0e2f44/aiohttp_prometheus_exporter-0.2.4-py2.py3-none-any.whl", hash = "sha256:8e32d12182d0c7728a7a68e7eefd1b35aa10150576c968dfd28cc63cb152e36b", size = 7525, upload-time = "2020-04-15T15:22:49.434Z" },
-]
-
-[[package]]
-name = "aiohttp-requests"
-version = "0.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp", extra = ["speedups"] },
-    { name = "coworker" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/2b/34ddd6fb516a8439ec5a860d7640050b49c94b64b7b134cbfbf5a21bbe17/aiohttp-requests-0.2.4.tar.gz", hash = "sha256:63036b83fabcf359aee33f957f7d8d12532c7d465c1343ab03a53faf38ae9e0c", size = 7070, upload-time = "2024-05-11T19:48:53.898Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/8f/723efa0175d71272432566bd85739257add08bd1381799141f62596cc2c5/aiohttp_requests-0.2.4-py3-none-any.whl", hash = "sha256:d201d699748f2e1459a49e8b7e53be1d05a487f3827c201a05941139678199b8", size = 4336, upload-time = "2024-05-11T19:48:52.234Z" },
-]
-
 [[package]]
 name = "aioitertools"
 version = "0.13.0"
@@ -199,19 +152,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fd/3c/53c4a17a05fb9ea2313ee1777ff53f5e001aefd5cc85aa2f4c2d982e1e38/aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c", size = 19322, upload-time = "2025-11-06T22:17:07.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be", size = 24182, upload-time = "2025-11-06T22:17:06.502Z" },
-]
-
-[[package]]
-name = "aioresponses"
-version = "0.7.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/03/532bbc645bdebcf3b6af3b25d46655259d66ce69abba7720b71ebfabbade/aioresponses-0.7.8.tar.gz", hash = "sha256:b861cdfe5dc58f3b8afac7b0a6973d5d7b2cb608dd0f6253d16b8ee8eaf6df11", size = 40253, upload-time = "2025-01-19T18:14:03.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b7/584157e43c98aa89810bc2f7099e7e01c728ecf905a66cf705106009228f/aioresponses-0.7.8-py2.py3-none-any.whl", hash = "sha256:b73bd4400d978855e55004b23a3a84cb0f018183bcf066a85ad392800b5b9a94", size = 12518, upload-time = "2025-01-19T18:13:59.633Z" },
 ]
 
 [[package]]
@@ -257,16 +197,14 @@ wheels = [
 [[package]]
 name = "ant31box"
 version = "0.4.0"
-source = { git = "https://github.com/ant31/ant31box.git?rev=main#b29abee7db697876f6f41f225d6448c5e570c8e7" }
+source = { git = "https://github.com/ant31/ant31box.git?rev=httpx#931c58fc8c88a3ec7ea113df4e663485edf0a4a7" }
 dependencies = [
     { name = "aioboto3" },
     { name = "aiofiles" },
-    { name = "aiohttp", extra = ["speedups"] },
-    { name = "aiohttp-prometheus-exporter" },
-    { name = "aiohttp-requests" },
     { name = "aioshutil" },
     { name = "asyncio" },
     { name = "cachetools" },
+    { name = "httpx" },
     { name = "paramiko" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -347,65 +285,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30", size = 780820, upload-time = "2023-12-31T06:30:32.926Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1", size = 60752, upload-time = "2023-12-31T06:30:30.772Z" },
-]
-
-[[package]]
-name = "backports-zstd"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/b1/36a5182ce1d8ef9ef32bff69037bd28b389bbdb66338f8069e61da7028cb/backports_zstd-1.3.0.tar.gz", hash = "sha256:e8b2d68e2812f5c9970cabc5e21da8b409b5ed04e79b4585dbffa33e9b45ebe2", size = 997138, upload-time = "2025-12-29T17:28:06.143Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/d4/356da49d3053f4bc50e71a8535631b57bc9ca4e8c6d2442e073e0ab41c44/backports_zstd-1.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f4a292e357f3046d18766ce06d990ccbab97411708d3acb934e63529c2ea7786", size = 435972, upload-time = "2025-12-29T17:26:18.752Z" },
-    { url = "https://files.pythonhosted.org/packages/30/8f/dbe389e60c7e47af488520f31a4aa14028d66da5bf3c60d3044b571eb906/backports_zstd-1.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fb4c386f38323698991b38edcc9c091d46d4713f5df02a3b5c80a28b40e289ea", size = 362124, upload-time = "2025-12-29T17:26:19.995Z" },
-    { url = "https://files.pythonhosted.org/packages/55/4b/173beafc99e99e7276ce008ef060b704471e75124c826bc5e2092815da37/backports_zstd-1.3.0-cp312-cp312-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f52523d2bdada29e653261abdc9cfcecd9e5500d305708b7e37caddb24909d4e", size = 506378, upload-time = "2025-12-29T17:26:21.855Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c8/3f12a411d9a99d262cdb37b521025eecc2aa7e4a93277be3f4f4889adb74/backports_zstd-1.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3321d00beaacbd647252a7f581c1e1cdbdbda2407f2addce4bfb10e8e404b7c7", size = 476201, upload-time = "2025-12-29T17:26:23.047Z" },
-    { url = "https://files.pythonhosted.org/packages/43/dc/73c090e4a2d5671422512e1b6d276ca6ea0cc0c45ec4634789106adc0d66/backports_zstd-1.3.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:88f94d238ef36c639c0ae17cf41054ce103da9c4d399c6a778ce82690d9f4919", size = 581659, upload-time = "2025-12-29T17:26:24.189Z" },
-    { url = "https://files.pythonhosted.org/packages/08/4f/11bfcef534aa2bf3f476f52130217b45337f334d8a287edb2e06744a6515/backports_zstd-1.3.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:97d8c78fe20c7442c810adccfd5e3ea6a4e6f4f1fa4c73da2bc083260ebead17", size = 640388, upload-time = "2025-12-29T17:26:25.47Z" },
-    { url = "https://files.pythonhosted.org/packages/71/17/8faea426d4f49b63238bdfd9f211a9f01c862efe0d756d3abeb84265a4e2/backports_zstd-1.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eefda80c3dbfbd924f1c317e7b0543d39304ee645583cb58bae29e19f42948ed", size = 494173, upload-time = "2025-12-29T17:26:26.736Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/9d/901f19ac90f3cd999bdcfb6edb4d7b4dc383dfba537f06f533fc9ac4777b/backports_zstd-1.3.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2ab5d3b5a54a674f4f6367bb9e0914063f22cd102323876135e9cc7a8f14f17e", size = 568628, upload-time = "2025-12-29T17:26:28.12Z" },
-    { url = "https://files.pythonhosted.org/packages/60/39/4d29788590c2465a570c2fae49dbff05741d1f0c8e4a0fb2c1c310f31804/backports_zstd-1.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7558fb0e8c8197c59a5f80c56bf8f56c3690c45fd62f14e9e2081661556e3e64", size = 482233, upload-time = "2025-12-29T17:26:29.399Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/4b/24c7c9e8ef384b19d515a7b1644a500ceb3da3baeff6d579687da1a0f62b/backports_zstd-1.3.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:27744870e38f017159b9c0241ea51562f94c7fefcfa4c5190fb3ec4a65a7fc63", size = 509806, upload-time = "2025-12-29T17:26:30.605Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/7e/7ba1aeecf0b5859f1855c0e661b4559566b64000f0627698ebd9e83f2138/backports_zstd-1.3.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b099750755bb74c280827c7d68de621da0f245189082ab48ff91bda0ec2db9df", size = 586037, upload-time = "2025-12-29T17:26:32.201Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1a/18f0402b36b9cfb0aea010b5df900cfd42c214f37493561dba3abac90c4e/backports_zstd-1.3.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5434e86f2836d453ae3e19a2711449683b7e21e107686838d12a255ad256ca99", size = 566220, upload-time = "2025-12-29T17:26:33.5Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/d9/44c098ab31b948bbfd909ec4ae08e1e44c5025a2d846f62991a62ab3ebea/backports_zstd-1.3.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:407e451f64e2f357c9218f5be4e372bb6102d7ae88582d415262a9d0a4f9b625", size = 630847, upload-time = "2025-12-29T17:26:35.273Z" },
-    { url = "https://files.pythonhosted.org/packages/30/33/e74cb2cfb162d2e9e00dad8bcdf53118ca7786cfd467925d6864732f79cc/backports_zstd-1.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58a071f3c198c781b2df801070290b7174e3ff61875454e9df93ab7ea9ea832b", size = 498665, upload-time = "2025-12-29T17:26:37.123Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/a9/67a24007c333ed22736d5cd79f1aa1d7209f09be772ff82a8fd724c1978e/backports_zstd-1.3.0-cp312-cp312-win32.whl", hash = "sha256:21a9a542ccc7958ddb51ae6e46d8ed25d585b54d0d52aaa1c8da431ea158046a", size = 288809, upload-time = "2025-12-29T17:26:38.373Z" },
-    { url = "https://files.pythonhosted.org/packages/42/24/34b816118ea913debb2ea23e71ffd0fb2e2ac738064c4ac32e3fb62c18bb/backports_zstd-1.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:89ea8281821123b071a06b30b80da8e4d8a2b40a4f57315a19850337a21297ac", size = 313815, upload-time = "2025-12-29T17:26:39.665Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/2f/babd02c9fc4ca35376ada7c291193a208165c7be2455f0f98bc1e1243f31/backports_zstd-1.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:f6843ecb181480e423b02f60fe29e393cbc31a95fb532acdf0d3a2c87bd50ce3", size = 288927, upload-time = "2025-12-29T17:26:40.923Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/7d/53e8da5950cdfc5e8fe23efd5165ce2f4fed5222f9a3292e0cdb03dd8c0d/backports_zstd-1.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e86e03e3661900955f01afed6c59cae9baa63574e3b66896d99b7de97eaffce9", size = 435463, upload-time = "2025-12-29T17:26:42.152Z" },
-    { url = "https://files.pythonhosted.org/packages/da/78/f98e53870f7404071a41e3d04f2ff514302eeeb3279d931d02b220f437aa/backports_zstd-1.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:41974dcacc9824c1effe1c8d2f9d762bcf47d265ca4581a3c63321c7b06c61f0", size = 361740, upload-time = "2025-12-29T17:26:43.377Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ed/2c64706205a944c9c346d95c17f632d4e3468db3ce60efb6f5caa7c0dcae/backports_zstd-1.3.0-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:3090a97738d6ce9545d3ca5446df43370928092a962cbc0153e5445a947e98ed", size = 505651, upload-time = "2025-12-29T17:26:44.495Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/7b/22998f691dc6e0c7e6fa81d611eb4b1f6a72fb27327f322366d4a7ca8fb3/backports_zstd-1.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ddc874638abf03ea1ff3b0525b4a26a8d0adf7cb46a448c3449f08e4abc276b3", size = 475859, upload-time = "2025-12-29T17:26:45.722Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/78/0cde898339a339530e5f932634872d2d64549969535447a48d3b98959e11/backports_zstd-1.3.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:db609e57b8ed88b3472930c87e93c08a4bbd5ffeb94608cd9c7c6f0ac0e166c6", size = 581339, upload-time = "2025-12-29T17:26:46.93Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/1d/e0973e0eebe678c12c146473af2c54cda8a3e63b179785ca1a20727ad69c/backports_zstd-1.3.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5f13033a3dd95f323c067199f2e61b4589a7880188ef4ef356c7ffbdb78a9f11", size = 642182, upload-time = "2025-12-29T17:26:48.545Z" },
-    { url = "https://files.pythonhosted.org/packages/82/a2/ac67e79e137eb98aead66c7162bafe3cffcb82ef9cdeb6367ec18d88fbce/backports_zstd-1.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c4c7bcda5619a754726e7f5b391827f5efbe4bed8e62e9ec7490d42bff18aa6", size = 490807, upload-time = "2025-12-29T17:26:49.789Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e9/3514b1d065801ae7dce05246e9389003ed8fb1d7c3d71f85aa07a80f41e6/backports_zstd-1.3.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:884a94c40f27affe986f394f219a4fd3cbbd08e1cff2e028d29d467574cd266e", size = 566103, upload-time = "2025-12-29T17:26:51.062Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/03/10ddb54cbf032e5fe390c0776d3392611b1fc772d6c3cb5a9bcdff4f915f/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:497f5765126f11a5b3fd8fedfdae0166d1dd867e7179b8148370a3313d047197", size = 481614, upload-time = "2025-12-29T17:26:52.255Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/13/21efa7f94c41447f43aee1563b05fc540a235e61bce4597754f6c11c2e97/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a6ff6769948bb29bba07e1c2e8582d5a9765192a366108e42d6581a458475881", size = 509207, upload-time = "2025-12-29T17:26:53.496Z" },
-    { url = "https://files.pythonhosted.org/packages/de/e7/12da9256d9e49e71030f0ff75e9f7c258e76091a4eaf5b5f414409be6a57/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1623e5bff1acd9c8ef90d24fc548110f20df2d14432bfe5de59e76fc036824ef", size = 585765, upload-time = "2025-12-29T17:26:54.99Z" },
-    { url = "https://files.pythonhosted.org/packages/24/bf/59ca9cb4e7be1e59331bb792e8ef1331828efe596b1a2f8cbbc4e3f70d75/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:622c28306dcc429c8f2057fc4421d5722b1f22968d299025b35d71b50cfd4e03", size = 563852, upload-time = "2025-12-29T17:26:56.371Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ee/5a3eaed9a73bdf2c35dc0c7adc0616a99588e0de28f5ab52f3e0caaaa96f/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09a2785e410ed2e812cb39b684ef5eb55083a5897bfd0e6f5de3bbd2c6345f70", size = 632549, upload-time = "2025-12-29T17:26:57.598Z" },
-    { url = "https://files.pythonhosted.org/packages/75/b9/c823633afc48a1ac56d6ad34289c8f51b0234685142531bfa8197ca91777/backports_zstd-1.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ade1f4127fdbe36a02f8067d75aa79c1ea1c8a306bf63c7b818bb7b530e1beaa", size = 495104, upload-time = "2025-12-29T17:26:58.826Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/8f/6f7030f18fa7307f87b0f57108a50a3a540b6350e2486d1739c0567629a3/backports_zstd-1.3.0-cp313-cp313-win32.whl", hash = "sha256:668e6fb1805b825cb7504c71436f7b28d4d792bb2663ee901ec9a2bb15804437", size = 288447, upload-time = "2025-12-29T17:27:00.036Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/82/b1df1bbbe4e6d3ffd364d0bcffdeb6c4361115c1eccd91238dbdd0c07fec/backports_zstd-1.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:385bdadf0ea8fe6ba780a95e4c7d7f018db7bafdd630932f0f9f0fad05d608ff", size = 313664, upload-time = "2025-12-29T17:27:01.267Z" },
-    { url = "https://files.pythonhosted.org/packages/45/0f/60918fe4d3f2881de8f4088d73be4837df9e4c6567594109d355a2d548b6/backports_zstd-1.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:4321a8a367537224b3559fe7aeb8012b98aea2a60a737e59e51d86e2e856fe0a", size = 288678, upload-time = "2025-12-29T17:27:02.506Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/b9/35f423c0bcd85020d5e7be6ab8d7517843e3e4441071beb5c3bd8c5216cb/backports_zstd-1.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:10057d66fa4f0a7d3f6419ffb84b4fe61088da572e3ac4446134a1c8089e4166", size = 436155, upload-time = "2025-12-29T17:27:03.859Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/14/e504daea24e8916f14ecbc223c354b558d8410cfc846606668ab91d96b38/backports_zstd-1.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4abf29d706ba05f658ca0247eb55675bcc00e10f12bca15736e45b05f1f2d2dc", size = 362436, upload-time = "2025-12-29T17:27:05.076Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f7/06e178dbab7edb88c2872aebd68b54137e07a169eba1aeedf614014f7036/backports_zstd-1.3.0-cp313-cp313t-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:127b0d73c745b0684da3d95c31c0939570810dad8967dfe8231eea8f0e047b2f", size = 507600, upload-time = "2025-12-29T17:27:06.254Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/f1/2ce499b81c4389d6fa1eeea7e76f6e0bad48effdbb239da7cbcdaaf24b76/backports_zstd-1.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0205ef809fb38bb5ca7f59fa03993596f918768b9378fb7fbd8a68889a6ce028", size = 475496, upload-time = "2025-12-29T17:27:07.939Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1e/c82a586f2866aabf3a601a521af3c58756d83d98b724fda200016ac5e7e2/backports_zstd-1.3.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c389b667b0b07915781aa28beabf2481f11a6062a1a081873c4c443b98601a7", size = 580919, upload-time = "2025-12-29T17:27:09.1Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/a3/eb5d9b7c4cb69d1b8ccd011abe244ba6815693b70bed07ed4b77ddda4535/backports_zstd-1.3.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8e7ac5ef693d49d6fb35cd7bbb98c4762cfea94a8bd2bf2ab112027004f70b11", size = 639913, upload-time = "2025-12-29T17:27:10.433Z" },
-    { url = "https://files.pythonhosted.org/packages/11/2c/7296b99df79d9f31174a99c81c1964a32de8996ce2b3068f5bc66b413615/backports_zstd-1.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d5543945aae2a76a850b23f283249424f535de6a622d6002957b7d971e6a36d", size = 494800, upload-time = "2025-12-29T17:27:11.59Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/fc/b8ae6e104ba72d20cd5f9dfd9baee36675e89c81d432434927967114f30f/backports_zstd-1.3.0-cp313-cp313t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e38be15ebce82737deda2c9410c1f942f1df9da74121049243a009810432db75", size = 570396, upload-time = "2025-12-29T17:27:13.063Z" },
-    { url = "https://files.pythonhosted.org/packages/30/56/60a7a9de7a5bc951ea1106358b413c95183c93480394f3abc541313c8679/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e3e3f58c76f4730607a4e0130d629173aa114ae72a5c8d3d5ad94e1bf51f18d8", size = 481980, upload-time = "2025-12-29T17:27:14.317Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/bb/93fc1e8e81b8ecba58b0e53a14f7b44375cf837db6354410998f0c4cb6ff/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:b808bf889722d889b792f7894e19c1f904bb0e9092d8c0eb0787b939b08bad9a", size = 511358, upload-time = "2025-12-29T17:27:15.669Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/0f/b165c2a6080d22306975cd86ce97270208493f31a298867e343110570370/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f7be27d56f2f715bcd252d0c65c232146d8e1e039c7e2835b8a3ad3dc88bc508", size = 585492, upload-time = "2025-12-29T17:27:16.986Z" },
-    { url = "https://files.pythonhosted.org/packages/26/76/85b4bde76e982b24a7eb57a2fb9868807887bef4d2114a3654a6530a67ef/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:cbe341c7fcc723893663a37175ba859328b907a4e6d2d40a4c26629cc55efb67", size = 568309, upload-time = "2025-12-29T17:27:18.28Z" },
-    { url = "https://files.pythonhosted.org/packages/83/64/9490667827a320766fb883f358a7c19171fdc04f19ade156a8c341c36967/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:b4116a9e12dfcd834dd9132cf6a94657bf0d328cba5b295f26de26ea0ae1adc8", size = 630518, upload-time = "2025-12-29T17:27:19.525Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/43/258587233b728bbff457bdb0c52b3e08504c485a8642b3daeb0bdd5a76bc/backports_zstd-1.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1049e804cc8754290b24dab383d4d6ed0b7f794ad8338813ddcb3907d15a89d0", size = 499429, upload-time = "2025-12-29T17:27:21.063Z" },
-    { url = "https://files.pythonhosted.org/packages/32/04/cfab76878f360f124dbb533779e1e4603c801a0f5ada72ae5c742b7c4d7d/backports_zstd-1.3.0-cp313-cp313t-win32.whl", hash = "sha256:7d3f0f2499d2049ec53d2674c605a4b3052c217cc7ee49c05258046411685adc", size = 289389, upload-time = "2025-12-29T17:27:22.287Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/ff/dbcfb6c9c922ab6d98f3d321e7d0c7b34ecfa26f3ca71d930fe1ef639737/backports_zstd-1.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:eb2f8fab0b1ea05148394cb34a9e543a43477178765f2d6e7c84ed332e34935e", size = 314776, upload-time = "2025-12-29T17:27:23.458Z" },
-    { url = "https://files.pythonhosted.org/packages/01/4b/82e4baae3117806639fe1c693b1f2f7e6133a7cefd1fa2e38018c8edcd68/backports_zstd-1.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c66ad9eb5bfbe28c2387b7fc58ddcdecfb336d6e4e60bcba1694a906c1f21a6c", size = 289315, upload-time = "2025-12-29T17:27:24.601Z" },
 ]
 
 [[package]]
@@ -550,65 +429,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
-]
-
-[[package]]
-name = "brotli"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
-    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
-    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
-    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
-    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
-    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
-    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
-    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
-    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
-    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
-    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
-]
-
-[[package]]
-name = "brotlicffi"
-version = "1.2.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/017dc5f852ed9b8735af77774509271acbf1de02d238377667145fcee01d/brotlicffi-1.2.0.1.tar.gz", hash = "sha256:c20d5c596278307ad06414a6d95a892377ea274a5c6b790c2548c009385d621c", size = 478156, upload-time = "2026-03-05T19:54:11.547Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/f9/dfa56316837fa798eac19358351e974de8e1e2ca9475af4cb90293cd6576/brotlicffi-1.2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c85e65913cf2b79c57a3fdd05b98d9731d9255dc0cb696b09376cc091b9cddd", size = 433046, upload-time = "2026-03-05T19:53:46.209Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/f5/f8f492158c76b0d940388801f04f747028971ad5774287bded5f1e53f08d/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:535f2d05d0273408abc13fc0eebb467afac17b0ad85090c8913690d40207dac5", size = 1541126, upload-time = "2026-03-05T19:53:48.248Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/e1/ff87af10ac419600c63e9287a0649c673673ae6b4f2bcf48e96cb2f89f60/brotlicffi-1.2.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce17eb798ca59ecec67a9bb3fd7a4304e120d1cd02953ce522d959b9a84d58ac", size = 1541983, upload-time = "2026-03-05T19:53:50.317Z" },
-    { url = "https://files.pythonhosted.org/packages/47/c0/80ecd9bd45776109fab14040e478bf63e456967c9ddee2353d8330ed8de1/brotlicffi-1.2.0.1-cp314-cp314t-win32.whl", hash = "sha256:3c9544f83cb715d95d7eab3af4adbbef8b2093ad6382288a83b3a25feb1a57ec", size = 349047, upload-time = "2026-03-05T19:53:52.215Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/98/13e5b250236a281b6cd9e92a01ee1ae231029fa78faee932ef3766e1cb24/brotlicffi-1.2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:625f8115d32ae9c0740d01ea51518437c3fbaa3e78d41cb18459f6f7ac326000", size = 385652, upload-time = "2026-03-05T19:53:53.892Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/9f/b98dcd4af47994cee97aebac866996a006a2e5fc1fd1e2b82a8ad95cf09c/brotlicffi-1.2.0.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:91ba5f0ccc040f6ff8f7efaf839f797723d03ed46acb8ae9408f99ffd2572cf4", size = 432608, upload-time = "2026-03-05T19:53:56.736Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/7a/ac4ee56595a061e3718a6d1ea7e921f4df156894acffb28ed88a1fd52022/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9a670c6811af30a4bd42d7116dc5895d3b41beaa8ed8a89050447a0181f5ce", size = 1534257, upload-time = "2026-03-05T19:53:58.667Z" },
-    { url = "https://files.pythonhosted.org/packages/99/39/e7410db7f6f56de57744ea52a115084ceb2735f4d44973f349bb92136586/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3314a3476f59e5443f9f72a6dff16edc0c3463c9b318feaef04ae3e4683f5a", size = 1536838, upload-time = "2026-03-05T19:54:00.705Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/75/6e7977d1935fc3fbb201cbd619be8f2c7aea25d40a096967132854b34708/brotlicffi-1.2.0.1-cp38-abi3-win32.whl", hash = "sha256:82ea52e2b5d3145b6c406ebd3efb0d55db718b7ad996bd70c62cec0439de1187", size = 343337, upload-time = "2026-03-05T19:54:02.446Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/ef/e7e485ce5e4ba3843a0a92feb767c7b6098fd6e65ce752918074d175ae71/brotlicffi-1.2.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:da2e82a08e7778b8bc539d27ca03cdd684113e81394bfaaad8d0dfc6a17ddede", size = 379026, upload-time = "2026-03-05T19:54:04.322Z" },
 ]
 
 [[package]]
@@ -897,15 +717,6 @@ wheels = [
 ]
 
 [[package]]
-name = "coworker"
-version = "2.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/cd/0bbed485ed06e1c82450a51a29d45926531a8b3e8d5e6838ed0b873cbd49/coworker-2.0.1.tar.gz", hash = "sha256:1bdf9b2c2feb368715434524ac5fda8d518fbff3b8827c7ee31c47eee46668f7", size = 13973, upload-time = "2023-09-30T01:35:41.948Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/53/7fd132410d8914154e10f41c89c285c4dadf408ca5e67a138387e90c04e1/coworker-2.0.1-py3-none-any.whl", hash = "sha256:51550ae1003b68b2e41ccbffbbdb058bda4b0b7734c3466adfda3e70999a77ea", size = 5502, upload-time = "2023-09-30T01:35:39.802Z" },
-]
-
-[[package]]
 name = "cryptography"
 version = "46.0.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1000,13 +811,13 @@ name = "enginepy"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "aiohttp-prometheus-exporter" },
     { name = "ant31box", extra = ["cli"] },
     { name = "asyncio" },
-    { name = "logfire", extra = ["aiohttp"] },
+    { name = "httpx" },
+    { name = "logfire", extra = ["httpx"] },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "respx" },
     { name = "rich" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "typer" },
@@ -1015,7 +826,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "aioresponses" },
     { name = "black" },
     { name = "bump-my-version" },
     { name = "coverage" },
@@ -1028,26 +838,26 @@ dev = [
     { name = "pyreadline" },
     { name = "pyright" },
     { name = "pytest" },
-    { name = "pytest-aioresponses" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-ordering" },
     { name = "requests" },
+    { name = "respx" },
     { name = "ruff" },
     { name = "types-requests" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp" },
-    { name = "aiohttp-prometheus-exporter" },
-    { name = "ant31box", extras = ["cli"], git = "https://github.com/ant31/ant31box.git?rev=main" },
+    { name = "ant31box", extras = ["cli"], git = "https://github.com/ant31/ant31box.git?rev=httpx" },
     { name = "asyncio", specifier = ">=3" },
-    { name = "logfire", extras = ["aiohttp"], specifier = ">=3.10.0,<4.0.0" },
+    { name = "httpx" },
+    { name = "logfire", extras = ["httpx"], specifier = ">=3.10.0,<4.0.0" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "pyyaml", specifier = ">=6.0,<7.0.0" },
+    { name = "respx", specifier = ">=0.23.1" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "sentry-sdk", extras = ["fastapi"] },
     { name = "typer" },
@@ -1056,7 +866,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aioresponses" },
     { name = "black" },
     { name = "bump-my-version", specifier = ">=1.2.0" },
     { name = "coverage" },
@@ -1069,12 +878,12 @@ dev = [
     { name = "pyreadline" },
     { name = "pyright" },
     { name = "pytest" },
-    { name = "pytest-aioresponses" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-ordering" },
     { name = "requests" },
+    { name = "respx" },
     { name = "ruff" },
     { name = "types-requests" },
 ]
@@ -1090,7 +899,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.0"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1099,9 +908,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -1432,8 +1241,8 @@ wheels = [
 ]
 
 [package.optional-dependencies]
-aiohttp = [
-    { name = "opentelemetry-instrumentation-aiohttp-client" },
+httpx = [
+    { name = "opentelemetry-instrumentation-httpx" },
 ]
 
 [[package]]
@@ -1748,7 +1557,7 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation-aiohttp-client"
+name = "opentelemetry-instrumentation-httpx"
 version = "0.56b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
@@ -1758,9 +1567,9 @@ dependencies = [
     { name = "opentelemetry-util-http" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/c9/3df52bc00207c2b74cbb55802ef5ec5a96d12338e7d733211237cf4e62ae/opentelemetry_instrumentation_aiohttp_client-0.56b0.tar.gz", hash = "sha256:f22b83812b697bc72dec23a175747538a826dec79f9bdb63d35af5a347108d4c", size = 15036, upload-time = "2025-07-11T12:26:20.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/93/784623262776d90aa07e5cc08f58e1d476ed4b208127c1718db4b57b78c8/opentelemetry_instrumentation_httpx-0.56b0.tar.gz", hash = "sha256:d93c7a0e0ce5cc2170f7cc0d26f19167bc8314b7d2a5204afdf84000d5ca8647", size = 19510, upload-time = "2025-07-11T12:26:37.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/e5/c8ec8e7ab2365f458fbc2041671ce1f1f216e71de3c1c2fddf7174827b10/opentelemetry_instrumentation_aiohttp_client-0.56b0-py3-none-any.whl", hash = "sha256:74f6facb7e8f682ba7f5a106b124ab0f3643c6f6781f2ef3e2982f50ad6fbbd1", size = 12375, upload-time = "2025-07-11T12:25:25.002Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0e/fe2f38e0170a22a44b26e9a8f555ac23b2fcf09f89264d718800ec1d5954/opentelemetry_instrumentation_httpx-0.56b0-py3-none-any.whl", hash = "sha256:34d9558413d695ea69fe002efa07c00aa859a8aa4930815726e5813d5f002e1d", size = 15113, upload-time = "2025-07-11T12:25:45.671Z" },
 ]
 
 [[package]]
@@ -1881,15 +1690,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]
@@ -2019,65 +1819,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
-]
-
-[[package]]
-name = "pycares"
-version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/a0/9c823651872e6a0face3f0311de2a40c8bbcb9c8dcb15680bd019ac56ac7/pycares-5.0.1.tar.gz", hash = "sha256:5a3c249c830432631439815f9a818463416f2a8cbdb1e988e78757de9ae75081", size = 652222, upload-time = "2026-01-01T12:37:00.604Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/67/e84ba11d3fec3bf1322c3b302c4df13c85e0a1bc48f16d65cd0f59ad9853/pycares-5.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ee551be4f3f3ac814ac8547586c464c9035e914f5122a534d25de147fa745e1", size = 136241, upload-time = "2026-01-01T12:35:25.439Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ae/50fbb3b4e52b9f1d16a36ffabd051ef8b2106b3f0a0d1c1113904d187a9d/pycares-5.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:252d4e5a52a68f825eaa90e16b595f9baee22c760f51e286ab612c6829b96de3", size = 131069, upload-time = "2026-01-01T12:35:26.293Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/ea/f431599f1ac42149ea4768e516db7cdae3a503a6646319ae63ab66da1486/pycares-5.0.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c1aa549b8c2f2e224215c793d660270778dcba9abc3b85abbc7c41eabe4f1e5", size = 221120, upload-time = "2026-01-01T12:35:27.143Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/4f/0a7a6c8b3a64ee5149e935c167cd8ba5d1fdd766ec03e273dbc7502f7bea/pycares-5.0.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:db7c9c9f16e8311998667a7488e817f8cbeedec2447bac827c71804663f1437e", size = 252228, upload-time = "2026-01-01T12:35:28.443Z" },
-    { url = "https://files.pythonhosted.org/packages/49/3d/7f9fd20e97ee30c4b959f87ab26e47ddcef666e5e7717e45f2245fe9d70a/pycares-5.0.1-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b9c4c8bb69bab863f677fa166653bb872bfa5d5a742f1f30bebc2d53b6e71db", size = 239473, upload-time = "2026-01-01T12:35:29.794Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/d0/c67967a10abd89529cb9aded9d73f43e5de00cf21243638ef529f6757262/pycares-5.0.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09ef90da8da3026fcba4ed223bd71e8057608d5b3fec4f5990b52ae1e8c855cc", size = 223831, upload-time = "2026-01-01T12:35:30.781Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/9a/94aacaf22a20b7d342c8f18bf006be57967beef6319adc668d4d86b627be/pycares-5.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ce193ebd54f4c74538b751ebb0923a9208c234ff180589d4d3cec134c001840e", size = 223963, upload-time = "2026-01-01T12:35:31.691Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/e1/3666aab6fc5e7d0c669b981fe0407e6a4b67e4e6a37ac429d440274663d5/pycares-5.0.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:36b9ff18ef231277f99a846feade50b417187a96f742689a9d08b9594e386de4", size = 251813, upload-time = "2026-01-01T12:35:32.918Z" },
-    { url = "https://files.pythonhosted.org/packages/94/44/ddab5fbc16ad0084a827167ae8628f54c7a55ce6b743585e6f47a5dd527e/pycares-5.0.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5e40ea4a0ef0c01a02ef7f7390a58c62d237d5ad48d36bc3245e9c2ac181cc22", size = 238181, upload-time = "2026-01-01T12:35:34.078Z" },
-    { url = "https://files.pythonhosted.org/packages/66/27/05467933e0e5c4e712302a2d7499797bc3029bf4d0d8ffbfe737254482b7/pycares-5.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f323b0ddfd2c7896af6fba4f8851d34d3d13387566aa573d93330fb01cb1038", size = 223552, upload-time = "2026-01-01T12:35:35.076Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/e2/14f3837e943d46ee12441fe6aaa418fdb2f698d42e179f368eaa9829744b/pycares-5.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:bdc6bcafb72a97b3cdd529fc87210e59e67feb647a7e138110656023599b84da", size = 117478, upload-time = "2026-01-01T12:35:36.133Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/c3/3284061f18188d5085338e1f1fd4f03d9c135657acf16f8020b9dd3be5fc/pycares-5.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:f8ef4c70c1edaf022875a8f9ff6c0c064f82831225acc91aa1b4f4d389e2e03a", size = 108889, upload-time = "2026-01-01T12:35:37.135Z" },
-    { url = "https://files.pythonhosted.org/packages/92/0a/6bd9bdc2d0ee23ff3aabab7747212e2c5323a081b9b745624d62df88f7e9/pycares-5.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d1b2c6b152c65f14d0e12d741fabb78a487f0f0d22773eede8d8cfc97af612b", size = 136242, upload-time = "2026-01-01T12:35:38.372Z" },
-    { url = "https://files.pythonhosted.org/packages/18/2a/2e9f888fc076cfe7a3493a3c4113e787cc4b4533f531dfb562ac9b04898f/pycares-5.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8c8ffcc9a48cfc296fe1aefc07d2c8e29a7f97e4bb366ce17effea6a38825f70", size = 131070, upload-time = "2026-01-01T12:35:39.262Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/5b/83b5aaf7b6ed102f63cd768a747b6cb5d4624f2eaecd84868d103b9dbf39/pycares-5.0.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8efc38c2703e3530b823a4165a7b28d7ce0fdcf41960fb7a4ca834a0f8cfe79", size = 221137, upload-time = "2026-01-01T12:35:40.155Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d3/d77ab0b33fb805d02896c385176c462e3386d94457a5e508245c39f41829/pycares-5.0.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e380bf6eff42c260f829a0a14547e13375e949053a966c23ca204a13647ef265", size = 252252, upload-time = "2026-01-01T12:35:41.287Z" },
-    { url = "https://files.pythonhosted.org/packages/14/32/8afbc798bce26dfcc5bc1f6bf1560d31cdd0af837ff52cbede657bf9262e/pycares-5.0.1-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:35dd5858ee1246bd092a212b5e85a8ef70853f7cfaf16b99569bf4af3ae4695d", size = 239447, upload-time = "2026-01-01T12:35:42.614Z" },
-    { url = "https://files.pythonhosted.org/packages/61/1b/a056393fda383b2eda5dab20bd0dd034fd631bf5ae754aabb20da815bdfe/pycares-5.0.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c257c6e7bf310cdb5823aa9d9a28f1e370fed8c653a968d38a954a8f8e0375ce", size = 223822, upload-time = "2026-01-01T12:35:43.594Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/c7/9817f0fb954ab9926f88403f2b91a3e4984a277e2b7a4563e0118e4e1ffa/pycares-5.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07711acb0ef75758f081fb7436acaccc91e8afd5ae34fd35d4edc44297e81f27", size = 223986, upload-time = "2026-01-01T12:35:44.893Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/a9/c0ea15c871c77e8c20bcaab18f56ae83988ea4c302155d106cc6a1bd83a9/pycares-5.0.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:30e5db1ae85cffb031dd8bc1b37903cd74c6d37eb737643bbca3ff2cd4bc6ae2", size = 251838, upload-time = "2026-01-01T12:35:46.271Z" },
-    { url = "https://files.pythonhosted.org/packages/be/a4/fe4068abfadf3e06cc22333e87e4730de3c170075572041d5545926062a3/pycares-5.0.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:efbe7f89425a14edbc94787042309be77cb3674415eb6079b356e1f9552ba747", size = 238238, upload-time = "2026-01-01T12:35:47.196Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/25/4f140518768d974af4221cfd574a30d99d40b3d5c54c479da2c1553be59e/pycares-5.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5de9e7ce52d638d78723c24704eb032e60b96fbb6fe90c6b3110882987251377", size = 223574, upload-time = "2026-01-01T12:35:48.191Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/0a/6e4afa4a2baffd1eba6c18a90cda17681d4838d3cab5a485e471386e04dc/pycares-5.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:0e99af0a1ce015ab6cc6bd85ce158d95ed89fb3b654515f1d0989d1afcf11026", size = 117472, upload-time = "2026-01-01T12:35:50.674Z" },
-    { url = "https://files.pythonhosted.org/packages/57/d0/a99f97e9aa8c8404fc899540cf30be63cda0df5150e3c0837423917c7e4c/pycares-5.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:2a511c9f3b11b7ce9f159c956ea1b8f2de7f419d7ca9fa24528d582cb015dbf9", size = 108889, upload-time = "2026-01-01T12:35:51.902Z" },
-    { url = "https://files.pythonhosted.org/packages/38/b2/4af99ff17acb81377c971831520540d1859bf401dc85712eb4abc2e6751f/pycares-5.0.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e330e3561be259ad7a1b7b0ce282c872938625f76587fae7ac8d6bc5af1d0c3d", size = 136635, upload-time = "2026-01-01T12:35:53.365Z" },
-    { url = "https://files.pythonhosted.org/packages/42/da/e2e1683811c427492ee0e86e8fae8d55eb5cca032220438599991fdad866/pycares-5.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:82bd37fec2a3fa62add30d4a3854720f7b051386e2f18e6e8f4ee94b89b5a7b0", size = 131093, upload-time = "2026-01-01T12:35:54.28Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/2a/9cf2120cafc19e5c589d5252a9ddd3108cc87e9db09938d16317807de03b/pycares-5.0.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:258c38aaa82ad1d565b4591cdb93d2c191be8e0a2c70926999c8e0b717a01f2a", size = 221096, upload-time = "2026-01-01T12:35:57.096Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/cc/c5fbf6377e2d6b1f1618f147ad898e5d8ae1585fc726d6301f07aeda6cac/pycares-5.0.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ccc1b2df8a09ca20eefbe20b9f7a484d376525c0fb173cfadd692320013c6bc5", size = 252330, upload-time = "2026-01-01T12:35:58.182Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/df/17a7c518c45bb994f76d9064d2519674e2a3950f895abbe6af123ead04ac/pycares-5.0.1-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3c4dfc80cc8b43dc79e02a15486c58eead5cae0a40906d6be64e2522285b5b39", size = 239799, upload-time = "2026-01-01T12:36:00.378Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/6c/d79c94809742b56b9180a9a9ec2937607db0b8eb34b8ca75d86d3114d6dd/pycares-5.0.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f498a6606247bfe896c2a4d837db711eb7b0ba23e409e16e4b23def4bada4b9d", size = 223501, upload-time = "2026-01-01T12:36:02.695Z" },
-    { url = "https://files.pythonhosted.org/packages/69/08/83084b67cbce08f44fd803b88816fc80d2fe2fb3d483d5432925df44371b/pycares-5.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a7d197835cdb4b202a3b12562b32799e27bb132262d4aa1ac3ee9d440e8ec22c", size = 223708, upload-time = "2026-01-01T12:36:04.357Z" },
-    { url = "https://files.pythonhosted.org/packages/15/57/63a6e9ef356c5149b8ec72a694e02207fd8ae643895aeb78a9f0c07f1502/pycares-5.0.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f78ab823732b050d658eb735d553726663c9bccdeeee0653247533a23eb2e255", size = 251816, upload-time = "2026-01-01T12:36:05.618Z" },
-    { url = "https://files.pythonhosted.org/packages/43/1c/1c85c6355cf7bc3ae86a1024d60f9cabdc12af63306a5f59370ac8718a41/pycares-5.0.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f444ab7f318e9b2c209b45496fb07bff5e7ada606e15d5253a162964aa078527", size = 238259, upload-time = "2026-01-01T12:36:07.609Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7f/bd5ff5a460e50433f993560e4e5d229559a8bf271dbdf6be832faf1973b5/pycares-5.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9de80997de7538619b7dd28ec4371e5172e3f9480e4fc648726d3d5ba661ca05", size = 223732, upload-time = "2026-01-01T12:36:09.893Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/fe/e77738366e00dc0918bbeb0c8fc63579e5d9cec748a2b838e207e548b5d9/pycares-5.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:206ce9f3cb9d51f5065c81b23c22996230fbc2cf58ae22834c623631b2b473aa", size = 120847, upload-time = "2026-01-01T12:36:11.494Z" },
-    { url = "https://files.pythonhosted.org/packages/81/17/758e9af7ee8589ac6deddf7ea56d75b982f155bc2052ef61c45d5f371389/pycares-5.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:45fb3b07231120e8cb5b75be7f15f16115003e9251991dc37a3e5c63733d63b5", size = 112595, upload-time = "2026-01-01T12:36:12.973Z" },
-    { url = "https://files.pythonhosted.org/packages/56/12/4f1d418fed957fc96089c69d9ec82314b3b91c48c7f9463385842acad9c4/pycares-5.0.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:602f3eac4b880a2527d21f52b2319cb10fde9225d103d338c4d0b2b07f136849", size = 137061, upload-time = "2026-01-01T12:36:15.027Z" },
-    { url = "https://files.pythonhosted.org/packages/29/8c/559cea98a8a5d0f38b50b4b812a07fdbcdb1a961bed9e2e9d5d343e53c6f/pycares-5.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1c3736deef003f0c57bc4e7f94d54270d0824350a8f5ceaba3a20b2ce8fb427", size = 131551, upload-time = "2026-01-01T12:36:16.74Z" },
-    { url = "https://files.pythonhosted.org/packages/34/cd/aee5d8070888d7be509d4f32a348e2821309ec67980498e5a974cd9e4990/pycares-5.0.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e63328df86d37150ce697fb5d9313d1d468dd4dddee1d09342cb2ed241ce6ad9", size = 230409, upload-time = "2026-01-01T12:36:18.909Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/94/15d5cf7d8e7af4b4ce3e19ea117dfe565c08d60d82f043ad23843703a135/pycares-5.0.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57f6fd696213329d9a69b9664a68b1ff2a71ccbdc1fc928a42c9a92858c1ec5d", size = 261297, upload-time = "2026-01-01T12:36:20.771Z" },
-    { url = "https://files.pythonhosted.org/packages/af/46/24f6ddc7a37ec6eaa1c38f617f39624211d8e7cdca49b644bfc5f467f275/pycares-5.0.1-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9d0878edabfbecb48a29e8769284003d8dbc05936122fe361849cd5fa52722e0", size = 248071, upload-time = "2026-01-01T12:36:22.925Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f0/7eb7fe44f0db55b9083725ab7a084874c2dc02806d9613e07e719838c2ab/pycares-5.0.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50e21f27a91be122e066ddd78c2d0d2769e547561481d8342a9d652a345b89f7", size = 232073, upload-time = "2026-01-01T12:36:25.773Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/cd/993b17e0c049a56b5af4df3fd053acc57b37e17e0dcd709b2d337c22d57d/pycares-5.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:97ceda969f5a5d5c6b15558b658c29e4301b3a2c4615523797b5f9d4ac74772e", size = 232815, upload-time = "2026-01-01T12:36:27.798Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/ff/170177bcc5dff31e735f209f5de63362f513ac18846c83d50e4e68f57866/pycares-5.0.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:4d1713e602ab09882c3e65499b2cc763bff0371117327cad704cf524268c2604", size = 261111, upload-time = "2026-01-01T12:36:29.94Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/4a/4c6497b8ca9279b4038ee8c7e2c49504008d594d06a044e00678b30c10fe/pycares-5.0.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:954a379055d6c66b2e878b52235b382168d1a3230793ff44454019394aecac5e", size = 246311, upload-time = "2026-01-01T12:36:31.352Z" },
-    { url = "https://files.pythonhosted.org/packages/06/19/1603f51f0d73bf34017a9e6967540c2bc138f9541aa7cc1ef38990b3ce9d/pycares-5.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:145d8a20f7fd1d58a2e49b7ef4309ec9bdcab479ac65c2e49480e20d3f890c23", size = 232027, upload-time = "2026-01-01T12:36:34.374Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/de/c000a682757b84688722ac232a24a86b6f195f1f4732432ecf35d0a768a5/pycares-5.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ebc9daba03c7ff3f62616c84c6cb37517445d15df00e1754852d6006039eb4a4", size = 121267, upload-time = "2026-01-01T12:36:35.741Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/c4/8bfffecd08b9b198113fcff5f0ab84bbe696f07dec46dd1ccae0e7b28c23/pycares-5.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:e0a86eff6bf9e91d5dd8876b1b82ee45704f46b1104c24291d3dea2c1fc8ebcb", size = 113043, upload-time = "2026-01-01T12:36:37.895Z" },
 ]
 
 [[package]]
@@ -2288,15 +2029,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/bc/7c/d724ef1ec3ab2125f
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]
@@ -2313,19 +2054,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
-]
-
-[[package]]
-name = "pytest-aioresponses"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aioresponses" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/15/f0/88ea99ad637726e12640199464268754f336c54b87e99f898d7c9926b71b/pytest_aioresponses-0.3.0.tar.gz", hash = "sha256:5677b32dfa1a36908b347524b5867aab35ac1c5ce1d4970244d6f66009bca7b6", size = 2718, upload-time = "2025-01-02T07:44:44.243Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/78/d7e10efd0e1c3ca9195d6de264536989a3a1f43baefed7d4a8ac79e2c938/pytest_aioresponses-0.3.0-py3-none-any.whl", hash = "sha256:60f3124ff05a0210a5f369dd95e4cf66090774ba76b322f7178858ce4e6c1647", size = 3289, upload-time = "2025-01-02T07:44:41.831Z" },
 ]
 
 [[package]]
@@ -2538,6 +2266,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/96/fb6dbfebb524d5601d359a47c78fe7ba1eef90fc4096404aa60c9a906fbb/requirements_parser-0.13.0.tar.gz", hash = "sha256:0843119ca2cb2331de4eb31b10d70462e39ace698fd660a915c247d2301a4418", size = 22630, upload-time = "2025-05-21T13:42:05.464Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/60/50fbb6ffb35f733654466f1a90d162bcbea358adc3b0871339254fbc37b2/requirements_parser-0.13.0-py3-none-any.whl", hash = "sha256:2b3173faecf19ec5501971b7222d38f04cb45bb9d87d0ad629ca71e2e62ded14", size = 14782, upload-time = "2025-05-21T13:42:04.007Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- **> refactor: migrate from aiohttp to httpx**
  - Replace aiohttp/aioresponses with httpx/respx in pyproject.toml
  - Update EngineClient and CLI to use httpx API and exceptions
  - Adjust logfire dependency to use httpx integration
  

- **> style: run linter and fix formatting in cli.py**
  

- **> refactor: complete migration from aiohttp to httpx and respx**
  - Update EngineClient for httpx response and timeout patterns
  - Transition test mocks from aioresponses to respx
  - Replace aiohttp error handling with httpx.HTTPStatusError
  

- **> refactor: update EngineClient to use httpx timeouts and response parsing**
  This change replaces aiohttp-specific structures with httpx equivalents across multiple API methods.
  - Replace `ClientTimeout` with `httpx.Timeout`
  - Remove `ssl` parameter and `await` from `json()` calls
  - Clean up inline comments in request parameters
  

- **> fix: fix respx assertions and pydantic json serialization**
  Resolve httpx migration regressions in tests and serialization.
  - Replace `mock.called` with `len(mock.calls) > 0` for respx
  - Use `mode="json"` in `model_dump()` for serializable payloads
  

- **> fix: use len(mock.calls) instead of mock.called in respx tests**
  

- **> fix: use len(mock.calls) instead of mock.called in respx tests**
  

- **> test: update mock call assertions in engine client tests**
  Use `len(mock.calls) > 0` instead of `mock.called` for better reliability in verifying requests in `test_update_doc_suggestions` test cases.
  

- **> docs: replace stale aiohttp references with httpx**
  Updates documentation and docstrings to reflect the migration from aiohttp
  to httpx that was previously completed in the implementation.
  
  - Update `README.md` client description
  - Replace `aiohttp.ClientResponseError` with `httpx.HTTPStatusError` in `EngineClient` docstrings
  

- **lint**
  